### PR TITLE
docs: prefer jj over git for VCS operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md
+## Version Control: Prefer jj
+
+Use `jj` (Jujutsu) for all VCS operations instead of `git`:
+- `jj status`, `jj diff`, `jj log` for inspection
+- `jj new` to start a change, `jj describe` to set the message
+- `jj commit` to commit, `jj push` to push
+- `jj squash`, `jj rebase`, `jj edit` for history manipulation
+
+Fall back to `git` only for operations not yet supported by `jj`.
+


### PR DESCRIPTION
Adds jj (Jujutsu) preference rule to CLAUDE.md so agents use jj instead of git.

## Summary by Sourcery

Documentation:
- Add CLAUDE.md guidelines instructing agents to use jj for standard version control operations and rely on git only when jj lacks support.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document preference for `jj` over `git` for version control operations
> Adds [CLAUDE.md](https://github.com/wopr-network/platform-core/pull/9/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) with version control guidelines that prefer `jj` (Jujutsu) commands for common VCS operations, falling back to `git` only for operations not supported by `jj`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4899b63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->