### PR TITLE
security: validate tenant access in isAuthed middleware (WOP-2110)

### DIFF
--- a/src/trpc/init.test.ts
+++ b/src/trpc/init.test.ts
@@ -118,6 +118,14 @@ describe("tRPC procedure builders", () => {
       const caller = createCaller({ user: { id: "u1", roles: ["user"] }, tenantId: undefined });
       expect(await caller.protectedHello()).toBe("protected-ok");
     });
+
+    it("allows platform_admin users with any tenantId without org check", async () => {
+      const repo = makeMockRepo({ findMember: vi.fn().mockResolvedValue(null) });
+      setTrpcOrgMemberRepo(repo);
+
+      const caller = createCaller({ user: { id: "admin1", roles: ["platform_admin"] }, tenantId: "any-tenant" });
+      expect(await caller.protectedHello()).toBe("protected-ok");
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -188,6 +196,14 @@ describe("tRPC procedure builders", () => {
 
       const caller = createCaller({ user: { id: "u1", roles: ["user"] }, tenantId: "org-other" });
       await expect(caller.tenantHello()).rejects.toThrow("Not authorized for this tenant");
+    });
+
+    it("allows platform_admin users to access any tenant without org check", async () => {
+      const repo = makeMockRepo({ findMember: vi.fn().mockResolvedValue(null) });
+      setTrpcOrgMemberRepo(repo);
+
+      const caller = createCaller({ user: { id: "admin1", roles: ["platform_admin"] }, tenantId: "any-tenant" });
+      expect(await caller.tenantHello()).toBe("tenant-ok");
     });
   });
 

--- a/src/trpc/init.ts
+++ b/src/trpc/init.ts
@@ -28,6 +28,9 @@ export interface TRPCContext {
 
 const t = initTRPC.context<TRPCContext>().create();
 
+/** Prefix used on user IDs for bearer-token-authenticated requests. */
+const BEARER_TOKEN_ID_PREFIX = "token:";
+
 // ---------------------------------------------------------------------------
 // Org member repo injection (for tenant access validation)
 // ---------------------------------------------------------------------------
@@ -53,8 +56,9 @@ const isAuthed = t.middleware(async ({ ctx, next }) => {
   }
 
   // Validate tenant access for session-cookie users when tenantId is present.
-  // Bearer token users (id starts with "token:") have server-assigned tenantId — skip check.
-  if (ctx.tenantId && !ctx.user.id.startsWith("token:")) {
+  // Bearer token users (id starts with BEARER_TOKEN_ID_PREFIX) and platform_admin users
+  // have server-assigned or unrestricted tenantId — skip check.
+  if (ctx.tenantId && !ctx.user.id.startsWith(BEARER_TOKEN_ID_PREFIX) && !ctx.user.roles.includes("platform_admin")) {
     if (!_orgMemberRepo) {
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
@@ -103,8 +107,9 @@ const isAuthedWithTenant = t.middleware(async ({ ctx, next }) => {
     throw new TRPCError({ code: "BAD_REQUEST", message: "Tenant context required" });
   }
 
-  // Validate tenant access for session-cookie users (bearer token users have server-assigned tenantId).
-  if (!ctx.user.id.startsWith("token:")) {
+  // Validate tenant access for session-cookie users (bearer token users have server-assigned tenantId;
+  // platform_admin users have access to all tenants).
+  if (!ctx.user.id.startsWith(BEARER_TOKEN_ID_PREFIX) && !ctx.user.roles.includes("platform_admin")) {
     if (!_orgMemberRepo) {
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",


### PR DESCRIPTION
## Summary
Closes WOP-2110

- Adds tenant membership validation to `isAuthed` middleware so every `protectedProcedure` (not just `tenantProcedure`) rejects forged `x-tenant-id` headers
- Bearer token users (id prefix `token:`) skip the check — their tenantId is server-assigned
- Requests without `tenantId` pass through unchanged (no-tenant requests remain valid)
- The redundant check in `isAuthedWithTenant` is preserved for defense in depth

## Test plan
- [ ] `npm run check` passes (biome + tsc)
- [ ] `npx vitest run src/trpc/init.test.ts` passes (22 tests, 5 new)
- New tests cover: forged tenantId rejection, personal tenant allow, org member allow, bearer token bypass, no-tenantId passthrough

Generated with Claude Code

## Summary by Sourcery

Strengthen authentication middleware to validate tenant access on all protected procedures and expand test coverage for tenant authorization behavior.

Enhancements:
- Enforce tenant membership validation for session-based users in the generic authentication middleware while preserving bearer-token and no-tenant flows.

Tests:
- Add tests covering tenant authorization for protected procedures, including forged tenant rejection, valid personal and org tenants, bearer-token bypass, and no-tenant requests.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate tenant access for session users in `isAuthed` middleware
> - Adds tenant access validation to `isAuthed` in [init.ts](https://github.com/wopr-network/platform-core/pull/13/files#diff-c3c8f02d8ab15fbe64e53f2fdd89237a29af44435581565c6da795b852ea5b58): when a `tenantId` is present, session-cookie users must be confirmed as org members before proceeding.
> - Bearer-token users (IDs prefixed with `BEARER_TOKEN_ID_PREFIX`) and `platform_admin` users bypass the org membership check in both `isAuthed` and `isAuthedWithTenant`.
> - Introduces the `BEARER_TOKEN_ID_PREFIX` constant (`"token:"`) to replace hardcoded string checks throughout.
> - Risk: `isAuthed` now throws `FORBIDDEN` if tenant access is denied, and `INTERNAL_SERVER_ERROR` if the org member repository is not wired — both are new failure modes for previously permissive routes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0309de3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->