### PR TITLE
test: replace weak toBeTruthy() with specific matchers (WOP-2135)

### DIFF
--- a/src/email/notification-templates.test.ts
+++ b/src/email/notification-templates.test.ts
@@ -8,9 +8,9 @@ describe("renderNotificationTemplate", () => {
         email: "user@example.com",
         creditsUrl: "https://app.wopr.bot/billing/credits",
       });
-      expect(result.subject).toBeTruthy();
+      expect(result.subject).toMatch(/.+/);
       expect(result.html).toContain("<!DOCTYPE html>");
-      expect(result.text).toBeTruthy();
+      expect(result.text).toMatch(/.+/);
     });
   });
 

--- a/src/middleware/rate-limit.test.ts
+++ b/src/middleware/rate-limit.test.ts
@@ -104,7 +104,7 @@ describe("rateLimit", () => {
 
     expect(res.headers.get("X-RateLimit-Limit")).toBe("5");
     expect(res.headers.get("X-RateLimit-Remaining")).toBe("4");
-    expect(res.headers.get("X-RateLimit-Reset")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Reset")).toMatch(/^\d+$/);
   });
 
   it("sets Retry-After header on 429", async () => {
@@ -115,7 +115,7 @@ describe("rateLimit", () => {
 
     expect(res.status).toBe(429);
     const retryAfter = res.headers.get("Retry-After");
-    expect(retryAfter).toBeTruthy();
+    expect(retryAfter).toEqual(expect.any(String));
     expect(Number(retryAfter)).toBeGreaterThan(0);
   });
 

--- a/src/security/tenant-keys/tenant-key-repository.test.ts
+++ b/src/security/tenant-keys/tenant-key-repository.test.ts
@@ -69,7 +69,7 @@ describe("TenantKeyRepository", () => {
     it("returns the full record including encrypted_key", async () => {
       await store.upsert("t1", "anthropic", fakeEncrypted);
       const record = await store.get("t1", "anthropic");
-      expect(record?.encrypted_key).toBeTruthy();
+      expect(record?.encrypted_key).toEqual(expect.any(String));
       const parsed = JSON.parse(record?.encrypted_key ?? "{}");
       expect(parsed.iv).toBe(fakeEncrypted.iv);
       expect(parsed.authTag).toBe(fakeEncrypted.authTag);

--- a/src/tenancy/org-repository.test.ts
+++ b/src/tenancy/org-repository.test.ts
@@ -64,7 +64,7 @@ describe("DrizzleOrgRepository", () => {
   describe("listByUser", () => {
     it("returns orgs where user has a role (via userIds)", async () => {
       const org = await repo.createOrg("user-1", "Org A", "org-a");
-      expect(await repo.getById(org.id)).toBeTruthy();
+      expect(await repo.getById(org.id)).not.toBeNull();
     });
   });
 


### PR DESCRIPTION
Replaces toBeTruthy() assertions with specific matchers (toMatch, not.toBeNull, toEqual(expect.any(String))) for stronger test correctness guarantees.

Closes WOP-2135

## Summary by Sourcery

Strengthen test assertions by replacing generic truthiness checks with more specific matchers across email, rate limiting, tenant key, and org repository tests.

Tests:
- Assert rendered email subjects and text are non-empty strings using regex-based matchers instead of generic truthiness checks.
- Validate rate limit headers with format-specific matchers, including numeric and string-type expectations, rather than toBeTruthy().
- Ensure tenant key and org repository tests assert presence and types of returned values with explicit matchers like not.toBeNull() and expect.any(String).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace weak `toBeTruthy()` assertions with specific matchers in tests
> Strengthens test assertions across four test files to catch type mismatches that `toBeTruthy()` would miss.
>
> - [notification-templates.test.ts](https://github.com/wopr-network/platform-core/pull/16/files#diff-beadb98eebb6a021e44dd266986579dd7a1d4f0f797cba3b55e13f5755eacbe0): asserts `subject` and `text` match `/.+/` instead of being any truthy value
> - [rate-limit.test.ts](https://github.com/wopr-network/platform-core/pull/16/files#diff-b3064d8249ebffbe4ba64c93846d51e70f775f5320a296b9666ba15dd0e037e0): asserts `X-RateLimit-Reset` matches `/^\d+$/` and `Retry-After` is a string
> - [tenant-key-repository.test.ts](https://github.com/wopr-network/platform-core/pull/16/files#diff-f8ed5889ab4227aea13aa74b6a07501d1e762dc4770a92b31e91753978af82e6): asserts `encrypted_key` is a string via `expect.any(String)`
> - [org-repository.test.ts](https://github.com/wopr-network/platform-core/pull/16/files#diff-b77ebd46a4da237dd4bfc119795f168fb2d3c0b2404219c5c7ccfe8def2a057e): asserts `getById` returns non-null via `not.toBeNull()`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d42c1d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->