### PR TITLE
feat: add DeepSeek direct provider adapter

### DIFF
--- a/src/monetization/adapters/deepseek.test.ts
+++ b/src/monetization/adapters/deepseek.test.ts
@@ -364,6 +364,17 @@ describe("createDeepSeekAdapter", () => {
       expect(result.result.model).toBe("deepseek-chat-v3.2-20260301");
     });
 
+    it("falls back to prompt when messages is empty array", async () => {
+      const response = chatCompletionResponse();
+      const fetchFn = vi.fn<FetchFn>().mockResolvedValueOnce(mockResponse(response));
+
+      const adapter = createDeepSeekAdapter(makeConfig(), fetchFn);
+      await adapter.generateText({ prompt: "use this prompt", messages: [] });
+
+      const body = JSON.parse(fetchFn.mock.calls[0][1]?.body as string);
+      expect(body.messages).toEqual([{ role: "user", content: "use this prompt" }]);
+    });
+
     it("throws when neither messages nor prompt provided", async () => {
       const fetchFn = vi.fn<FetchFn>();
       const adapter = createDeepSeekAdapter(makeConfig(), fetchFn);

--- a/src/monetization/adapters/deepseek.ts
+++ b/src/monetization/adapters/deepseek.ts
@@ -95,7 +95,7 @@ export function createDeepSeekAdapter(
 
       const body: Record<string, unknown> = {
         model,
-        messages: input.messages ?? [{ role: "user", content: input.prompt }],
+        messages: input.messages?.length ? input.messages : [{ role: "user", content: input.prompt }],
       };
       if (input.maxTokens !== undefined) {
         body.max_tokens = input.maxTokens;


### PR DESCRIPTION
## Summary

- Adds `DeepSeekAdapter` implementing `ProviderAdapter` interface, hitting `api.deepseek.com` directly — bypasses OpenRouter's 5.5% credit fee
- Cache-aware costing: detects DeepSeek's `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` and charges cached input at $0.014/1M (90% off vs $0.14/1M standard)
- Prefers `messages` array over single prompt for multi-turn conversations
- Default pricing: $0.14/1M input, $0.28/1M output (DeepSeek V3.2 March 2026 rates)

## Why

OpenRouter charges 5.5% on credit purchases. At scale, routing DeepSeek traffic direct saves that fee on every request. DeepSeek V3.2 is the cheapest frontier-class model — this is the highest-margin adapter in the stack.

## Test plan

- [x] 21 unit tests covering cost calculation, cache pricing, margin, model override, error handling, edge cases
- [x] `biome check` clean
- [x] `tsc --noEmit` clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DeepSeek direct provider adapter with cache-aware pricing
> - Adds [`createDeepSeekAdapter`](https://github.com/wopr-network/platform-core/pull/19/files#diff-88d737b5d3ac732697f49e65239bc667453f88743c5c2a6672425f4cd31dab93) factory that implements `ProviderAdapter` for the DeepSeek API, supporting `text-generation` via chat completions.
> - Builds requests from either `messages` or a plain `prompt` string, with configurable model, `max_tokens`, and `temperature`.
> - Computes input cost using cache-aware pricing when `prompt_cache_hit_tokens`/`prompt_cache_miss_tokens` are present; falls back to standard per-token pricing otherwise.
> - Throws enriched errors on HTTP 429 (with optional `retryAfter`) and detailed errors on other non-OK responses.
> - Adds a full Vitest suite in [`deepseek.test.ts`](https://github.com/wopr-network/platform-core/pull/19/files#diff-1ffbeff1b1acea1c02ab0d93a4dc6d26e62aee56e12204dc3291dc65eaaa5ae8) covering cost calculation, margin application, error handling, and request construction edge cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54b45f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek integration for text generation with OpenAI-compatible API support.
  * Configurable adapter options: custom base URL, default model, pricing, API key, margin, and pluggable fetch.
  * Cache-aware pricing (includes discounted cached input) and model override via input.
  * Robust error handling (auth, rate limits with retry-after, server errors) and request/response handling.

* **Tests**
  * Extensive test suite covering initialization, pricing, caching scenarios, request format, usage extraction, model selection, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->