### PR TITLE
feat: add MiniMax direct provider adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Clean stale symlinks
+        run: |
+          [ -L node_modules ] && unlink node_modules || true
+          [ -L dist ] && unlink dist || true
+
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
@@ -35,6 +40,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Clean stale symlinks
+        run: |
+          [ -L node_modules ] && unlink node_modules || true
+          [ -L dist ] && unlink dist || true
+
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
@@ -56,6 +66,11 @@ jobs:
       checks: write
       pull-requests: write
     steps:
+      - name: Clean stale symlinks
+        run: |
+          [ -L node_modules ] && unlink node_modules || true
+          [ -L dist ] && unlink dist || true
+
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4

--- a/src/monetization/adapters/minimax.test.ts
+++ b/src/monetization/adapters/minimax.test.ts
@@ -292,6 +292,17 @@ describe("createMiniMaxAdapter", () => {
       expect(result.result.model).toBe("minimax-m2-20260301");
     });
 
+    it("falls back to prompt when messages is empty array", async () => {
+      const response = chatCompletionResponse();
+      const fetchFn = vi.fn<FetchFn>().mockResolvedValueOnce(mockResponse(response));
+
+      const adapter = createMiniMaxAdapter(makeConfig(), fetchFn);
+      await adapter.generateText({ prompt: "use this prompt", messages: [] });
+
+      const body = JSON.parse(fetchFn.mock.calls[0][1]?.body as string);
+      expect(body.messages).toEqual([{ role: "user", content: "use this prompt" }]);
+    });
+
     it("throws when neither messages nor prompt provided", async () => {
       const fetchFn = vi.fn<FetchFn>();
       const adapter = createMiniMaxAdapter(makeConfig(), fetchFn);

--- a/src/monetization/adapters/minimax.ts
+++ b/src/monetization/adapters/minimax.ts
@@ -87,7 +87,7 @@ export function createMiniMaxAdapter(
 
       const body: Record<string, unknown> = {
         model,
-        messages: input.messages ?? [{ role: "user", content: input.prompt }],
+        messages: input.messages?.length ? input.messages : [{ role: "user", content: input.prompt }],
       };
       if (input.maxTokens !== undefined) {
         body.max_tokens = input.maxTokens;


### PR DESCRIPTION
## Summary

- Adds `MiniMaxAdapter` implementing `ProviderAdapter` interface, hitting `api.minimax.chat` directly — bypasses OpenRouter's 5.5% credit fee
- Supports MiniMax M2 and M2.5 models via model override
- Prefers `messages` array over single prompt for multi-turn conversations
- Default pricing: $0.255/1M input, $1.00/1M output (MiniMax M2 March 2026 rates)

## Why

Second direct-provider adapter for inference arbitrage. MiniMax M2 sits between DeepSeek ($0.28/1M out) and OpenRouter-routed models ($1-15/1M out) — gives the arbitrage router another price tier to optimize against.

## Test plan

- [x] 17 unit tests covering cost calculation, margin, model override, messages passthrough, error handling, edge cases
- [x] `biome check` clean
- [x] `tsc --noEmit` clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a MiniMax provider adapter for direct text-generation with cost and margin calculation based on MiniMax token usage.

New Features:
- Introduce a MiniMax text-generation adapter that calls MiniMax's OpenAI-compatible chat completions API directly.
- Support configurable MiniMax models, base URL, pricing, and margin multiplier for inference arbitrage.

Tests:
- Add unit test suite validating MiniMax adapter behavior, including pricing and margin calculations, model overrides, request shaping, response parsing, and error handling.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MiniMax direct provider adapter for text generation
> - Adds [`createMiniMaxAdapter`](https://github.com/wopr-network/platform-core/pull/20/files#diff-329de7ea7169dd48b659a631ff705c8779b8f8d44d6e9744b63d88e60fb99de1) factory implementing the `text-generation` capability against the MiniMax chat completions endpoint (`/v1/chat/completions`).
> - Supports model override, optional `maxTokens`/`temperature`, and falls back from `messages` to a `prompt`-wrapped user message.
> - Computes USD cost from per-1M token rates and applies a margin multiplier to produce the final charge.
> - Handles HTTP 429 with a typed error (`httpStatus=429`) and propagates `retryAfter` from response headers when present.
> - CI jobs now unlink stale `node_modules` and `dist` symlinks before checkout to prevent runner cache conflicts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6be1f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added MiniMax text generation provider with support for customizable models and API configuration.
* Automatic token usage tracking and dynamic cost calculation with adjustable margins.
* Robust error handling including rate-limit detection with retry guidance.

## Tests

* Comprehensive test suite for provider validation and behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->