### PR TITLE
feat: add text-generation adapter factory

### DIFF
--- a/src/monetization/adapters/text-gen-factory.test.ts
+++ b/src/monetization/adapters/text-gen-factory.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { createTextGenAdapters, createTextGenAdaptersFromEnv } from "./text-gen-factory.js";
+
+describe("createTextGenAdapters", () => {
+  it("creates all adapters when all keys provided", () => {
+    const result = createTextGenAdapters({
+      deepseekApiKey: "sk-ds",
+      geminiApiKey: "sk-gem",
+      minimaxApiKey: "sk-mm",
+      kimiApiKey: "sk-kimi",
+      openrouterApiKey: "sk-or",
+    });
+
+    expect(result.adapters).toHaveLength(5);
+    expect(result.adapterMap.size).toBe(5);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("returns adapters in cost-priority order", () => {
+    const result = createTextGenAdapters({
+      deepseekApiKey: "sk-ds",
+      geminiApiKey: "sk-gem",
+      minimaxApiKey: "sk-mm",
+      kimiApiKey: "sk-kimi",
+      openrouterApiKey: "sk-or",
+    });
+
+    const names = result.adapters.map((a) => a.name);
+    expect(names).toEqual(["deepseek", "gemini", "minimax", "kimi", "openrouter"]);
+  });
+
+  it("skips adapters without API keys", () => {
+    const result = createTextGenAdapters({
+      deepseekApiKey: "sk-ds",
+      openrouterApiKey: "sk-or",
+    });
+
+    expect(result.adapters).toHaveLength(2);
+    expect(result.adapterMap.has("deepseek")).toBe(true);
+    expect(result.adapterMap.has("openrouter")).toBe(true);
+    expect(result.skipped).toEqual(["gemini", "minimax", "kimi"]);
+  });
+
+  it("skips adapters with empty string API keys", () => {
+    const result = createTextGenAdapters({
+      deepseekApiKey: "",
+      geminiApiKey: "sk-gem",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("gemini");
+    expect(result.skipped).toContain("deepseek");
+  });
+
+  it("returns empty result when no keys provided", () => {
+    const result = createTextGenAdapters({});
+
+    expect(result.adapters).toHaveLength(0);
+    expect(result.adapterMap.size).toBe(0);
+    expect(result.skipped).toEqual(["deepseek", "gemini", "minimax", "kimi", "openrouter"]);
+  });
+
+  it("all adapters support text-generation capability", () => {
+    const result = createTextGenAdapters({
+      deepseekApiKey: "sk-ds",
+      geminiApiKey: "sk-gem",
+      minimaxApiKey: "sk-mm",
+      kimiApiKey: "sk-kimi",
+      openrouterApiKey: "sk-or",
+    });
+
+    for (const adapter of result.adapters) {
+      expect(adapter.capabilities).toContain("text-generation");
+    }
+  });
+
+  it("all adapters implement generateText", () => {
+    const result = createTextGenAdapters({
+      deepseekApiKey: "sk-ds",
+      geminiApiKey: "sk-gem",
+      minimaxApiKey: "sk-mm",
+      kimiApiKey: "sk-kimi",
+      openrouterApiKey: "sk-or",
+    });
+
+    for (const adapter of result.adapters) {
+      expect(typeof adapter.generateText).toBe("function");
+    }
+  });
+
+  it("adapterMap keys match adapter names", () => {
+    const result = createTextGenAdapters({
+      deepseekApiKey: "sk-ds",
+      geminiApiKey: "sk-gem",
+    });
+
+    for (const [key, adapter] of result.adapterMap) {
+      expect(key).toBe(adapter.name);
+    }
+  });
+
+  it("passes per-adapter config overrides", () => {
+    const result = createTextGenAdapters({
+      deepseekApiKey: "sk-ds",
+      deepseek: { defaultModel: "deepseek-reasoner" },
+    });
+
+    // Adapter was created — we can't inspect internal config directly,
+    // but we can confirm it was created successfully with override
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("deepseek");
+  });
+
+  it("creates only one adapter for single-provider config", () => {
+    const result = createTextGenAdapters({
+      kimiApiKey: "sk-kimi",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("kimi");
+    expect(result.skipped).toEqual(["deepseek", "gemini", "minimax", "openrouter"]);
+  });
+});
+
+describe("createTextGenAdaptersFromEnv", () => {
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads API keys from environment variables", () => {
+    vi.stubEnv("DEEPSEEK_API_KEY", "env-ds");
+    vi.stubEnv("GEMINI_API_KEY", "env-gem");
+    vi.stubEnv("MINIMAX_API_KEY", "");
+    vi.stubEnv("KIMI_API_KEY", "");
+    vi.stubEnv("OPENROUTER_API_KEY", "env-or");
+
+    const result = createTextGenAdaptersFromEnv();
+
+    expect(result.adapters).toHaveLength(3);
+    const names = result.adapters.map((a) => a.name);
+    expect(names).toEqual(["deepseek", "gemini", "openrouter"]);
+    expect(result.skipped).toEqual(["minimax", "kimi"]);
+  });
+
+  it("returns empty when no env vars set", () => {
+    vi.stubEnv("DEEPSEEK_API_KEY", "");
+    vi.stubEnv("GEMINI_API_KEY", "");
+    vi.stubEnv("MINIMAX_API_KEY", "");
+    vi.stubEnv("KIMI_API_KEY", "");
+    vi.stubEnv("OPENROUTER_API_KEY", "");
+
+    const result = createTextGenAdaptersFromEnv();
+
+    expect(result.adapters).toHaveLength(0);
+    expect(result.skipped).toHaveLength(5);
+  });
+
+  it("accepts per-adapter overrides alongside env keys", () => {
+    vi.stubEnv("DEEPSEEK_API_KEY", "env-ds");
+    vi.stubEnv("GEMINI_API_KEY", "");
+    vi.stubEnv("MINIMAX_API_KEY", "");
+    vi.stubEnv("KIMI_API_KEY", "");
+    vi.stubEnv("OPENROUTER_API_KEY", "");
+
+    const result = createTextGenAdaptersFromEnv({
+      deepseek: { marginMultiplier: 1.5 },
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("deepseek");
+  });
+});

--- a/src/monetization/adapters/text-gen-factory.ts
+++ b/src/monetization/adapters/text-gen-factory.ts
@@ -1,0 +1,129 @@
+/**
+ * Text-generation adapter factory — instantiates all available text-gen
+ * adapters from environment config and returns them ready to register.
+ *
+ * Only adapters with a non-empty API key are created. The factory never
+ * touches the database — it returns plain ProviderAdapter instances that
+ * the caller registers with an ArbitrageRouter or AdapterSocket.
+ *
+ * Priority order (cheapest first):
+ *   GPU (self-hosted) → DeepSeek → Gemini → MiniMax → Kimi → OpenRouter
+ */
+
+import { createDeepSeekAdapter, type DeepSeekAdapterConfig } from "./deepseek.js";
+import { createGeminiAdapter, type GeminiAdapterConfig } from "./gemini.js";
+import { createKimiAdapter, type KimiAdapterConfig } from "./kimi.js";
+import { createMiniMaxAdapter, type MiniMaxAdapterConfig } from "./minimax.js";
+import { createOpenRouterAdapter, type OpenRouterAdapterConfig } from "./openrouter.js";
+import type { ProviderAdapter } from "./types.js";
+
+/** Top-level factory config. Only providers with an API key are instantiated. */
+export interface TextGenFactoryConfig {
+  /** DeepSeek API key. Omit or empty string to skip. */
+  deepseekApiKey?: string;
+  /** Gemini (Google) API key. Omit or empty string to skip. */
+  geminiApiKey?: string;
+  /** MiniMax API key. Omit or empty string to skip. */
+  minimaxApiKey?: string;
+  /** Kimi (Moonshot) API key. Omit or empty string to skip. */
+  kimiApiKey?: string;
+  /** OpenRouter API key. Omit or empty string to skip. */
+  openrouterApiKey?: string;
+  /** Per-adapter config overrides (base URL, model, margin, pricing, etc.) */
+  deepseek?: Omit<Partial<DeepSeekAdapterConfig>, "apiKey">;
+  gemini?: Omit<Partial<GeminiAdapterConfig>, "apiKey">;
+  minimax?: Omit<Partial<MiniMaxAdapterConfig>, "apiKey">;
+  kimi?: Omit<Partial<KimiAdapterConfig>, "apiKey">;
+  openrouter?: Omit<Partial<OpenRouterAdapterConfig>, "apiKey">;
+}
+
+/** Result of the factory — adapters + metadata for observability. */
+export interface TextGenFactoryResult {
+  /** All instantiated adapters, ordered by cost priority (cheapest first). */
+  adapters: ProviderAdapter[];
+  /** Map of adapter name → ProviderAdapter for direct registration with ArbitrageRouter. */
+  adapterMap: Map<string, ProviderAdapter>;
+  /** Names of providers that were skipped (no API key). */
+  skipped: string[];
+}
+
+/**
+ * Create text-generation adapters from the provided config.
+ *
+ * Returns only adapters whose API key is present and non-empty.
+ * Order matches arbitrage priority: cheapest first.
+ */
+export function createTextGenAdapters(config: TextGenFactoryConfig): TextGenFactoryResult {
+  const adapters: ProviderAdapter[] = [];
+  const skipped: string[] = [];
+
+  // DeepSeek — $0.14/$0.28 per 1M tokens (cheapest hosted)
+  if (config.deepseekApiKey) {
+    adapters.push(createDeepSeekAdapter({ apiKey: config.deepseekApiKey, ...config.deepseek }));
+  } else {
+    skipped.push("deepseek");
+  }
+
+  // Gemini — $0.10/$0.40 per 1M tokens (cheapest input)
+  if (config.geminiApiKey) {
+    adapters.push(createGeminiAdapter({ apiKey: config.geminiApiKey, ...config.gemini }));
+  } else {
+    skipped.push("gemini");
+  }
+
+  // MiniMax — $0.255/$1.00 per 1M tokens
+  if (config.minimaxApiKey) {
+    adapters.push(createMiniMaxAdapter({ apiKey: config.minimaxApiKey, ...config.minimax }));
+  } else {
+    skipped.push("minimax");
+  }
+
+  // Kimi — $0.35/$1.40 per 1M tokens
+  if (config.kimiApiKey) {
+    adapters.push(createKimiAdapter({ apiKey: config.kimiApiKey, ...config.kimi }));
+  } else {
+    skipped.push("kimi");
+  }
+
+  // OpenRouter — variable pricing, most expensive fallback
+  if (config.openrouterApiKey) {
+    adapters.push(createOpenRouterAdapter({ apiKey: config.openrouterApiKey, ...config.openrouter }));
+  } else {
+    skipped.push("openrouter");
+  }
+
+  const adapterMap = new Map<string, ProviderAdapter>();
+  for (const adapter of adapters) {
+    adapterMap.set(adapter.name, adapter);
+  }
+
+  return { adapters, adapterMap, skipped };
+}
+
+/**
+ * Create text-generation adapters from environment variables.
+ *
+ * Reads API keys from:
+ *   - DEEPSEEK_API_KEY
+ *   - GEMINI_API_KEY
+ *   - MINIMAX_API_KEY
+ *   - KIMI_API_KEY
+ *   - OPENROUTER_API_KEY
+ *
+ * Accepts optional per-adapter overrides for pricing, base URL, etc.
+ */
+export function createTextGenAdaptersFromEnv(
+  overrides?: Omit<
+    TextGenFactoryConfig,
+    "deepseekApiKey" | "geminiApiKey" | "minimaxApiKey" | "kimiApiKey" | "openrouterApiKey"
+  >,
+): TextGenFactoryResult {
+  return createTextGenAdapters({
+    deepseekApiKey: process.env.DEEPSEEK_API_KEY,
+    geminiApiKey: process.env.GEMINI_API_KEY,
+    minimaxApiKey: process.env.MINIMAX_API_KEY,
+    kimiApiKey: process.env.KIMI_API_KEY,
+    openrouterApiKey: process.env.OPENROUTER_API_KEY,
+    ...overrides,
+  });
+}

--- a/src/monetization/index.ts
+++ b/src/monetization/index.ts
@@ -56,6 +56,13 @@ export {
 export { createReplicateAdapter, type ReplicateAdapterConfig } from "./adapters/replicate.js";
 // Self-hosted adapter utilities (WOP-497)
 export { checkHealth, type FetchFn, type SelfHostedAdapterConfig } from "./adapters/self-hosted-base.js";
+// Text-generation adapter factory (WOP-463)
+export {
+  createTextGenAdapters,
+  createTextGenAdaptersFromEnv,
+  type TextGenFactoryConfig,
+  type TextGenFactoryResult,
+} from "./adapters/text-gen-factory.js";
 export {
   type AdapterCapability,
   type AdapterResult,


### PR DESCRIPTION
## Summary
- `createTextGenAdapters(config)` — instantiate adapters from explicit API keys, returns them in cost-priority order
- `createTextGenAdaptersFromEnv()` — reads `DEEPSEEK_API_KEY`, `GEMINI_API_KEY`, `MINIMAX_API_KEY`, `KIMI_API_KEY`, `OPENROUTER_API_KEY` from env
- Only creates adapters with non-empty keys, reports skipped providers
- Returns `{ adapters, adapterMap, skipped }` — `adapterMap` plugs directly into `ArbitrageRouter`

### Usage in wopr-platform
```ts
import { createTextGenAdaptersFromEnv, ArbitrageRouter } from "@wopr-network/platform-core/monetization";

const { adapterMap } = createTextGenAdaptersFromEnv();
const router = new ArbitrageRouter({ registry, adapters: adapterMap });
```

## Test plan
- [x] 13 tests — all combos, env reading, overrides, empty keys, single provider
- [x] lint, format, build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a text-generation adapter factory that instantiates and wires multiple provider adapters from configuration or environment variables for use with ArbitrageRouter.

New Features:
- Add a configurable text-generation adapter factory that builds provider adapters for DeepSeek, Gemini, MiniMax, Kimi, and OpenRouter from supplied API keys.
- Expose a convenience factory that reads text-generation provider API keys from environment variables and returns adapters plus a name-keyed adapter map.

Tests:
- Add unit tests for the text-generation adapter factory, covering environment-based configuration, overrides, provider inclusion/exclusion, and adapter ordering.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add text-generation adapter factory with cost-priority ordering and env var support
> - Adds `createTextGenAdapters` in [`text-gen-factory.ts`](https://github.com/wopr-network/platform-core/pull/24/files#diff-efdbcc2efa0acc737338f38ad4b032d004f8991d5aa2c86cc0e469eef66a59d5), which builds `ProviderAdapter` instances for deepseek, gemini, minimax, kimi, and openrouter in cost-priority order, skipping any provider whose API key is absent or empty.
> - Adds `createTextGenAdaptersFromEnv` that reads keys from environment variables (`DEEPSEEK_API_KEY`, `GEMINI_API_KEY`, etc.) and delegates to `createTextGenAdapters` with optional per-adapter overrides.
> - Both functions return `{ adapters, adapterMap, skipped }` where `adapterMap` is keyed by adapter name.
> - Exports all factory functions and types from the monetization package index.
> - Unit tests in [`text-gen-factory.test.ts`](https://github.com/wopr-network/platform-core/pull/24/files#diff-3d45921ca3de782ad6fe3ced7269f13c7b435ebbf37693a7105816fe6f88ce4a) cover ordering, key-skipping, capability presence, env var reading, and config overrides.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4db4fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->