### PR TITLE
feat: add TTS and transcription adapter factories

### DIFF
--- a/src/monetization/adapters/rate-table.test.ts
+++ b/src/monetization/adapters/rate-table.test.ts
@@ -138,6 +138,13 @@ describe("getRatesForCapability", () => {
     expect(rates.map((r) => r.tier)).toContain("premium");
   });
 
+  it("returns premium-only for transcription (no standard tier yet)", () => {
+    const rates = getRatesForCapability("transcription");
+    expect(rates).toHaveLength(1);
+    expect(rates[0].tier).toBe("premium");
+    expect(rates[0].provider).toBe("deepgram");
+  });
+
   it("returns empty array for non-existent capability", () => {
     const rates = getRatesForCapability("image-generation" as unknown as AdapterCapability);
     expect(rates).toHaveLength(0);
@@ -178,7 +185,8 @@ describe("calculateSavings", () => {
   });
 
   it("returns zero when capability has no standard tier", () => {
-    const savings = calculateSavings("image-generation" as unknown as AdapterCapability, 1000);
+    // Transcription only has premium (deepgram) — no self-hosted whisper yet
+    const savings = calculateSavings("transcription", 1000);
     expect(savings).toBe(0);
   });
 

--- a/src/monetization/adapters/rate-table.ts
+++ b/src/monetization/adapters/rate-table.ts
@@ -83,8 +83,21 @@ export const RATE_TABLE: RateEntry[] = [
     effectivePrice: 0.0000013, // = costPerUnit * margin ($1.30 per 1M tokens)
   },
 
+  // Transcription - Speech-to-Text
+  // NOTE: No self-hosted whisper adapter yet — only premium (deepgram) available.
+  // When self-hosted-whisper lands, add a standard tier entry here.
+  {
+    capability: "transcription",
+    tier: "premium",
+    provider: "deepgram",
+    costPerUnit: 0.0000717, // $0.0043/min = $0.0000717/sec
+    billingUnit: "per-second",
+    margin: 1.3, // 30% — dashboard default; runtime uses getMargin()
+    effectivePrice: 0.00009321, // = costPerUnit * margin ($93.21 per 1M seconds ≈ $5.59 per 1M minutes)
+  },
+
   // Future self-hosted adapters will add more entries here:
-  // - transcription: self-hosted-whisper (standard) vs deepgram (premium)
+  // - transcription: self-hosted-whisper (standard) — when GPU adapter exists
   // - embeddings: self-hosted-embeddings (standard) vs openrouter (premium)
   // - image-generation: self-hosted-sdxl (standard) vs replicate (premium)
 ];

--- a/src/monetization/adapters/transcription-factory.test.ts
+++ b/src/monetization/adapters/transcription-factory.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { createTranscriptionAdapters, createTranscriptionAdaptersFromEnv } from "./transcription-factory.js";
+
+describe("createTranscriptionAdapters", () => {
+  it("creates deepgram adapter when API key provided", () => {
+    const result = createTranscriptionAdapters({
+      deepgramApiKey: "sk-dg",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapterMap.size).toBe(1);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("returns deepgram as only adapter", () => {
+    const result = createTranscriptionAdapters({
+      deepgramApiKey: "sk-dg",
+    });
+
+    expect(result.adapters[0].name).toBe("deepgram");
+  });
+
+  it("skips deepgram when no API key", () => {
+    const result = createTranscriptionAdapters({});
+
+    expect(result.adapters).toHaveLength(0);
+    expect(result.skipped).toEqual(["deepgram"]);
+  });
+
+  it("skips deepgram with empty string API key", () => {
+    const result = createTranscriptionAdapters({
+      deepgramApiKey: "",
+    });
+
+    expect(result.adapters).toHaveLength(0);
+    expect(result.skipped).toContain("deepgram");
+  });
+
+  it("adapter supports transcription capability", () => {
+    const result = createTranscriptionAdapters({
+      deepgramApiKey: "sk-dg",
+    });
+
+    expect(result.adapters[0].capabilities).toContain("transcription");
+  });
+
+  it("adapter implements transcribe", () => {
+    const result = createTranscriptionAdapters({
+      deepgramApiKey: "sk-dg",
+    });
+
+    expect(typeof result.adapters[0].transcribe).toBe("function");
+  });
+
+  it("adapterMap keys match adapter names", () => {
+    const result = createTranscriptionAdapters({
+      deepgramApiKey: "sk-dg",
+    });
+
+    for (const [key, adapter] of result.adapterMap) {
+      expect(key).toBe(adapter.name);
+    }
+  });
+
+  it("passes per-adapter config overrides", () => {
+    const result = createTranscriptionAdapters({
+      deepgramApiKey: "sk-dg",
+      deepgram: { costPerMinute: 0.005, defaultModel: "nova-2-general" },
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("deepgram");
+  });
+});
+
+describe("createTranscriptionAdaptersFromEnv", () => {
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads API keys from environment variables", () => {
+    vi.stubEnv("DEEPGRAM_API_KEY", "env-dg");
+
+    const result = createTranscriptionAdaptersFromEnv();
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("deepgram");
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("returns empty when no env vars set", () => {
+    vi.stubEnv("DEEPGRAM_API_KEY", "");
+
+    const result = createTranscriptionAdaptersFromEnv();
+
+    expect(result.adapters).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+  });
+
+  it("accepts per-adapter overrides alongside env keys", () => {
+    vi.stubEnv("DEEPGRAM_API_KEY", "env-dg");
+
+    const result = createTranscriptionAdaptersFromEnv({
+      deepgram: { marginMultiplier: 1.5 },
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("deepgram");
+  });
+});

--- a/src/monetization/adapters/transcription-factory.ts
+++ b/src/monetization/adapters/transcription-factory.ts
@@ -1,0 +1,79 @@
+/**
+ * Transcription adapter factory — instantiates all available STT adapters
+ * from environment config and returns them ready to register.
+ *
+ * Only adapters with valid config are created. The factory never touches
+ * the database — it returns plain ProviderAdapter instances that the caller
+ * registers with an ArbitrageRouter or AdapterSocket.
+ *
+ * Priority order (cheapest first, when all adapters available):
+ *   self-hosted-whisper (GPU, cheapest) → Deepgram ($0.0043/min, third-party)
+ *
+ * NOTE: Self-hosted Whisper adapter doesn't exist yet. When it does, it
+ * will slot in as the GPU tier (cheapest) ahead of Deepgram.
+ */
+
+import { createDeepgramAdapter, type DeepgramAdapterConfig } from "./deepgram.js";
+import type { ProviderAdapter } from "./types.js";
+
+/** Top-level factory config. Only providers with an API key are instantiated. */
+export interface TranscriptionFactoryConfig {
+  /** Deepgram API key. Omit or empty string to skip. */
+  deepgramApiKey?: string;
+  /** Per-adapter config overrides */
+  deepgram?: Omit<Partial<DeepgramAdapterConfig>, "apiKey">;
+}
+
+/** Result of the factory — adapters + metadata for observability. */
+export interface TranscriptionFactoryResult {
+  /** All instantiated adapters, ordered by cost priority (cheapest first). */
+  adapters: ProviderAdapter[];
+  /** Map of adapter name → ProviderAdapter for direct registration. */
+  adapterMap: Map<string, ProviderAdapter>;
+  /** Names of providers that were skipped (no API key). */
+  skipped: string[];
+}
+
+/**
+ * Create transcription adapters from the provided config.
+ *
+ * Returns only adapters whose API key is present and non-empty.
+ * Order matches arbitrage priority: cheapest first.
+ */
+export function createTranscriptionAdapters(config: TranscriptionFactoryConfig): TranscriptionFactoryResult {
+  const adapters: ProviderAdapter[] = [];
+  const skipped: string[] = [];
+
+  // Deepgram — $0.0043/min (Nova-2 wholesale)
+  if (config.deepgramApiKey) {
+    adapters.push(createDeepgramAdapter({ apiKey: config.deepgramApiKey, ...config.deepgram }));
+  } else {
+    skipped.push("deepgram");
+  }
+
+  // Future: self-hosted-whisper will go BEFORE deepgram (GPU tier, cheapest)
+
+  const adapterMap = new Map<string, ProviderAdapter>();
+  for (const adapter of adapters) {
+    adapterMap.set(adapter.name, adapter);
+  }
+
+  return { adapters, adapterMap, skipped };
+}
+
+/**
+ * Create transcription adapters from environment variables.
+ *
+ * Reads API keys from:
+ *   - DEEPGRAM_API_KEY
+ *
+ * Accepts optional per-adapter overrides.
+ */
+export function createTranscriptionAdaptersFromEnv(
+  overrides?: Omit<TranscriptionFactoryConfig, "deepgramApiKey">,
+): TranscriptionFactoryResult {
+  return createTranscriptionAdapters({
+    deepgramApiKey: process.env.DEEPGRAM_API_KEY,
+    ...overrides,
+  });
+}

--- a/src/monetization/adapters/tts-factory.test.ts
+++ b/src/monetization/adapters/tts-factory.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { createTTSAdapters, createTTSAdaptersFromEnv } from "./tts-factory.js";
+
+describe("createTTSAdapters", () => {
+  it("creates both adapters when all config provided", () => {
+    const result = createTTSAdapters({
+      chatterboxBaseUrl: "http://chatterbox:8000",
+      elevenlabsApiKey: "sk-el",
+    });
+
+    expect(result.adapters).toHaveLength(2);
+    expect(result.adapterMap.size).toBe(2);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("returns adapters in cost-priority order (GPU first)", () => {
+    const result = createTTSAdapters({
+      chatterboxBaseUrl: "http://chatterbox:8000",
+      elevenlabsApiKey: "sk-el",
+    });
+
+    const names = result.adapters.map((a) => a.name);
+    expect(names).toEqual(["chatterbox-tts", "elevenlabs"]);
+  });
+
+  it("skips chatterbox when no base URL", () => {
+    const result = createTTSAdapters({
+      elevenlabsApiKey: "sk-el",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("elevenlabs");
+    expect(result.skipped).toEqual(["chatterbox-tts"]);
+  });
+
+  it("skips elevenlabs when no API key", () => {
+    const result = createTTSAdapters({
+      chatterboxBaseUrl: "http://chatterbox:8000",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("chatterbox-tts");
+    expect(result.skipped).toEqual(["elevenlabs"]);
+  });
+
+  it("skips elevenlabs with empty string API key", () => {
+    const result = createTTSAdapters({
+      chatterboxBaseUrl: "http://chatterbox:8000",
+      elevenlabsApiKey: "",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.skipped).toContain("elevenlabs");
+  });
+
+  it("returns empty result when no config provided", () => {
+    const result = createTTSAdapters({});
+
+    expect(result.adapters).toHaveLength(0);
+    expect(result.adapterMap.size).toBe(0);
+    expect(result.skipped).toEqual(["chatterbox-tts", "elevenlabs"]);
+  });
+
+  it("all adapters support tts capability", () => {
+    const result = createTTSAdapters({
+      chatterboxBaseUrl: "http://chatterbox:8000",
+      elevenlabsApiKey: "sk-el",
+    });
+
+    for (const adapter of result.adapters) {
+      expect(adapter.capabilities).toContain("tts");
+    }
+  });
+
+  it("all adapters implement synthesizeSpeech", () => {
+    const result = createTTSAdapters({
+      chatterboxBaseUrl: "http://chatterbox:8000",
+      elevenlabsApiKey: "sk-el",
+    });
+
+    for (const adapter of result.adapters) {
+      expect(typeof adapter.synthesizeSpeech).toBe("function");
+    }
+  });
+
+  it("adapterMap keys match adapter names", () => {
+    const result = createTTSAdapters({
+      chatterboxBaseUrl: "http://chatterbox:8000",
+      elevenlabsApiKey: "sk-el",
+    });
+
+    for (const [key, adapter] of result.adapterMap) {
+      expect(key).toBe(adapter.name);
+    }
+  });
+
+  it("chatterbox adapter is marked self-hosted", () => {
+    const result = createTTSAdapters({
+      chatterboxBaseUrl: "http://chatterbox:8000",
+    });
+
+    expect(result.adapters[0].selfHosted).toBe(true);
+  });
+
+  it("elevenlabs adapter is not marked self-hosted", () => {
+    const result = createTTSAdapters({
+      elevenlabsApiKey: "sk-el",
+    });
+
+    expect(result.adapters[0].selfHosted).toBeUndefined();
+  });
+
+  it("passes per-adapter config overrides", () => {
+    const result = createTTSAdapters({
+      chatterboxBaseUrl: "http://chatterbox:8000",
+      chatterbox: { costPerChar: 0.000001 },
+      elevenlabsApiKey: "sk-el",
+      elevenlabs: { defaultVoice: "custom-voice" },
+    });
+
+    expect(result.adapters).toHaveLength(2);
+  });
+});
+
+describe("createTTSAdaptersFromEnv", () => {
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads config from environment variables", () => {
+    vi.stubEnv("CHATTERBOX_BASE_URL", "http://chatterbox:8000");
+    vi.stubEnv("ELEVENLABS_API_KEY", "env-el");
+
+    const result = createTTSAdaptersFromEnv();
+
+    expect(result.adapters).toHaveLength(2);
+    const names = result.adapters.map((a) => a.name);
+    expect(names).toEqual(["chatterbox-tts", "elevenlabs"]);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("returns empty when no env vars set", () => {
+    vi.stubEnv("CHATTERBOX_BASE_URL", "");
+    vi.stubEnv("ELEVENLABS_API_KEY", "");
+
+    const result = createTTSAdaptersFromEnv();
+
+    expect(result.adapters).toHaveLength(0);
+    expect(result.skipped).toHaveLength(2);
+  });
+
+  it("accepts per-adapter overrides alongside env config", () => {
+    vi.stubEnv("CHATTERBOX_BASE_URL", "http://chatterbox:8000");
+    vi.stubEnv("ELEVENLABS_API_KEY", "");
+
+    const result = createTTSAdaptersFromEnv({
+      chatterbox: { costPerChar: 0.000001 },
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("chatterbox-tts");
+  });
+});

--- a/src/monetization/adapters/tts-factory.ts
+++ b/src/monetization/adapters/tts-factory.ts
@@ -1,0 +1,93 @@
+/**
+ * TTS adapter factory — instantiates all available TTS adapters from
+ * environment config and returns them ready to register.
+ *
+ * Only adapters with valid config are created. The factory never touches
+ * the database — it returns plain ProviderAdapter instances that the caller
+ * registers with an ArbitrageRouter or AdapterSocket.
+ *
+ * Priority order (cheapest first):
+ *   GPU (chatterbox-tts, self-hosted) → ElevenLabs (third-party)
+ */
+
+import { type ChatterboxTTSAdapterConfig, createChatterboxTTSAdapter } from "./chatterbox-tts.js";
+import { createElevenLabsAdapter, type ElevenLabsAdapterConfig } from "./elevenlabs.js";
+import type { ProviderAdapter } from "./types.js";
+
+/** Top-level factory config. Chatterbox needs a base URL; ElevenLabs needs an API key. */
+export interface TTSFactoryConfig {
+  /** Chatterbox GPU container base URL (e.g., "http://chatterbox:8000"). Omit to skip. */
+  chatterboxBaseUrl?: string;
+  /** ElevenLabs API key. Omit or empty string to skip. */
+  elevenlabsApiKey?: string;
+  /** Per-adapter config overrides */
+  chatterbox?: Omit<Partial<ChatterboxTTSAdapterConfig>, "baseUrl">;
+  elevenlabs?: Omit<Partial<ElevenLabsAdapterConfig>, "apiKey">;
+}
+
+/** Result of the factory — adapters + metadata for observability. */
+export interface TTSFactoryResult {
+  /** All instantiated adapters, ordered by cost priority (cheapest first). */
+  adapters: ProviderAdapter[];
+  /** Map of adapter name → ProviderAdapter for direct registration. */
+  adapterMap: Map<string, ProviderAdapter>;
+  /** Names of providers that were skipped (missing config). */
+  skipped: string[];
+}
+
+/**
+ * Create TTS adapters from the provided config.
+ *
+ * Returns only adapters whose required config is present.
+ * Order matches arbitrage priority: GPU (cheapest) first.
+ */
+export function createTTSAdapters(config: TTSFactoryConfig): TTSFactoryResult {
+  const adapters: ProviderAdapter[] = [];
+  const skipped: string[] = [];
+
+  // Chatterbox — self-hosted GPU, $2.00/1M chars wholesale, $2.40/1M effective (cheapest)
+  if (config.chatterboxBaseUrl) {
+    adapters.push(
+      createChatterboxTTSAdapter({
+        baseUrl: config.chatterboxBaseUrl,
+        costPerUnit: 0.000002,
+        ...config.chatterbox,
+      }),
+    );
+  } else {
+    skipped.push("chatterbox-tts");
+  }
+
+  // ElevenLabs — third-party, ~$15/1M chars (premium)
+  if (config.elevenlabsApiKey) {
+    adapters.push(createElevenLabsAdapter({ apiKey: config.elevenlabsApiKey, ...config.elevenlabs }));
+  } else {
+    skipped.push("elevenlabs");
+  }
+
+  const adapterMap = new Map<string, ProviderAdapter>();
+  for (const adapter of adapters) {
+    adapterMap.set(adapter.name, adapter);
+  }
+
+  return { adapters, adapterMap, skipped };
+}
+
+/**
+ * Create TTS adapters from environment variables.
+ *
+ * Reads config from:
+ *   - CHATTERBOX_BASE_URL
+ *   - ELEVENLABS_API_KEY
+ *
+ * Accepts optional per-adapter overrides.
+ */
+export function createTTSAdaptersFromEnv(
+  overrides?: Omit<TTSFactoryConfig, "chatterboxBaseUrl" | "elevenlabsApiKey">,
+): TTSFactoryResult {
+  return createTTSAdapters({
+    chatterboxBaseUrl: process.env.CHATTERBOX_BASE_URL,
+    elevenlabsApiKey: process.env.ELEVENLABS_API_KEY,
+    ...overrides,
+  });
+}

--- a/src/monetization/index.ts
+++ b/src/monetization/index.ts
@@ -65,6 +65,20 @@ export {
   type TextGenFactoryConfig,
   type TextGenFactoryResult,
 } from "./adapters/text-gen-factory.js";
+// Transcription adapter factory
+export {
+  createTranscriptionAdapters,
+  createTranscriptionAdaptersFromEnv,
+  type TranscriptionFactoryConfig,
+  type TranscriptionFactoryResult,
+} from "./adapters/transcription-factory.js";
+// TTS adapter factory
+export {
+  createTTSAdapters,
+  createTTSAdaptersFromEnv,
+  type TTSFactoryConfig,
+  type TTSFactoryResult,
+} from "./adapters/tts-factory.js";
 export {
   type AdapterCapability,
   type AdapterResult,


### PR DESCRIPTION
## Summary
- Adds `tts-factory.ts` — creates chatterbox-tts (GPU, self-hosted) and elevenlabs (third-party) adapters from config/env
- Adds `transcription-factory.ts` — creates deepgram adapter from config/env (self-hosted whisper will slot in when ready)
- Adds transcription (deepgram) entry to rate table
- Mirrors existing `text-gen-factory.ts` pattern: factory function + fromEnv variant, cost-priority ordering, skip-on-missing-key

Both factories return `{ adapters, adapterMap, skipped }` for direct registration with `AdapterSocket` or `ArbitrageRouter`.

## Test plan
- [x] 15 tests for TTS factory (both adapters, skip logic, self-hosted flag, env vars)
- [x] 11 tests for transcription factory (deepgram, skip logic, env vars)
- [x] Updated rate-table tests: transcription premium-only entry, savings with no standard tier
- [x] `pnpm lint && pnpm format && pnpm build` pass
- [x] All 50 adapter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce configurable factories for TTS and transcription adapters and add pricing for Deepgram transcription to the monetization rate table.

New Features:
- Add a TTS adapter factory that instantiates chatterbox-tts and ElevenLabs adapters from configuration or environment variables.
- Add a transcription adapter factory that instantiates a Deepgram adapter from configuration or environment variables.

Enhancements:
- Extend the monetization rate table with a premium Deepgram transcription entry and document future self-hosted tiers.

Tests:
- Add tests covering the new TTS and transcription adapter factories and update rate table tests for transcription pricing and savings behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TTS and transcription adapter factories to the monetization package
> - Adds [`createTTSAdapters`](https://github.com/wopr-network/platform-core/pull/26/files#diff-1ea2da9621b99a4c0c0c58353c3353f18f6eb4f30b345e41e5f2165637e3fd46) and [`createTTSAdaptersFromEnv`](https://github.com/wopr-network/platform-core/pull/26/files#diff-1ea2da9621b99a4c0c0c58353c3353f18f6eb4f30b345e41e5f2165637e3fd46) which instantiate chatterbox-tts (self-hosted) and ElevenLabs adapters in cost-priority order based on `CHATTERBOX_BASE_URL` and `ELEVENLABS_API_KEY`.
> - Adds [`createTranscriptionAdapters`](https://github.com/wopr-network/platform-core/pull/26/files#diff-dccdb2daf451e0724770f28c2ef39cb16334c4b0dad292bb4177975595f7a88a) and [`createTranscriptionAdaptersFromEnv`](https://github.com/wopr-network/platform-core/pull/26/files#diff-dccdb2daf451e0724770f28c2ef39cb16334c4b0dad292bb4177975595f7a88a) which instantiate a Deepgram adapter when `DEEPGRAM_API_KEY` is present.
> - Both factories return an ordered `adapters` array, a `name→adapter` map, and a `skipped` list for providers with missing config.
> - Adds a `transcription` entry to [`RATE_TABLE`](https://github.com/wopr-network/platform-core/pull/26/files#diff-98b8ee273a5dd20062357a4b70d1c168d8fdcaf8778f1f0536f1232ef45ebc60) with a Deepgram premium tier at `0.0000717` per second (no standard self-hosted tier yet).
> - All new factories and types are re-exported from [`src/monetization/index.ts`](https://github.com/wopr-network/platform-core/pull/26/files#diff-2d2742977742e4bb4e6f7e7a0002080b24fdb080e4081b930fbcec0a04184fca).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84dee01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->