### PR TITLE
feat: add image generation adapter factory (WOP-2188)

### DIFF
--- a/src/monetization/adapters/image-gen-factory.test.ts
+++ b/src/monetization/adapters/image-gen-factory.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { createImageGenAdapters, createImageGenAdaptersFromEnv } from "./image-gen-factory.js";
+
+describe("createImageGenAdapters", () => {
+  it("creates both adapters when all keys provided", () => {
+    const result = createImageGenAdapters({
+      geminiApiKey: "sk-gem",
+      replicateApiToken: "r8-rep",
+    });
+
+    expect(result.adapters).toHaveLength(2);
+    expect(result.adapterMap.size).toBe(2);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("returns adapters in cost-priority order (cheapest first)", () => {
+    const result = createImageGenAdapters({
+      geminiApiKey: "sk-gem",
+      replicateApiToken: "r8-rep",
+    });
+
+    const names = result.adapters.map((a) => a.name);
+    expect(names).toEqual(["replicate", "nano-banana"]);
+  });
+
+  it("skips nano-banana when no Gemini API key", () => {
+    const result = createImageGenAdapters({
+      replicateApiToken: "r8-rep",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("replicate");
+    expect(result.skipped).toEqual(["nano-banana"]);
+  });
+
+  it("skips replicate when no API token", () => {
+    const result = createImageGenAdapters({
+      geminiApiKey: "sk-gem",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("nano-banana");
+    expect(result.skipped).toEqual(["replicate"]);
+  });
+
+  it("skips adapters with empty string keys", () => {
+    const result = createImageGenAdapters({
+      geminiApiKey: "",
+      replicateApiToken: "r8-rep",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("replicate");
+    expect(result.skipped).toContain("nano-banana");
+  });
+
+  it("returns empty result when no keys provided", () => {
+    const result = createImageGenAdapters({});
+
+    expect(result.adapters).toHaveLength(0);
+    expect(result.adapterMap.size).toBe(0);
+    expect(result.skipped).toEqual(["replicate", "nano-banana"]);
+  });
+
+  it("all adapters support image-generation capability", () => {
+    const result = createImageGenAdapters({
+      geminiApiKey: "sk-gem",
+      replicateApiToken: "r8-rep",
+    });
+
+    for (const adapter of result.adapters) {
+      expect(adapter.capabilities).toContain("image-generation");
+    }
+  });
+
+  it("all adapters implement generateImage", () => {
+    const result = createImageGenAdapters({
+      geminiApiKey: "sk-gem",
+      replicateApiToken: "r8-rep",
+    });
+
+    for (const adapter of result.adapters) {
+      expect(typeof adapter.generateImage).toBe("function");
+    }
+  });
+
+  it("adapterMap keys match adapter names", () => {
+    const result = createImageGenAdapters({
+      geminiApiKey: "sk-gem",
+      replicateApiToken: "r8-rep",
+    });
+
+    for (const [key, adapter] of result.adapterMap) {
+      expect(key).toBe(adapter.name);
+    }
+  });
+
+  it("passes per-adapter config overrides", () => {
+    const result = createImageGenAdapters({
+      geminiApiKey: "sk-gem",
+      nanoBanana: { costPerImage: 0.01 },
+      replicateApiToken: "r8-rep",
+      replicate: { marginMultiplier: 1.5 },
+    });
+
+    expect(result.adapters).toHaveLength(2);
+  });
+
+  it("creates only one adapter for single-provider config", () => {
+    const result = createImageGenAdapters({
+      geminiApiKey: "sk-gem",
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("nano-banana");
+    expect(result.skipped).toEqual(["replicate"]);
+  });
+});
+
+describe("createImageGenAdaptersFromEnv", () => {
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads keys from environment variables", () => {
+    vi.stubEnv("GEMINI_API_KEY", "env-gem");
+    vi.stubEnv("REPLICATE_API_TOKEN", "env-rep");
+
+    const result = createImageGenAdaptersFromEnv();
+
+    expect(result.adapters).toHaveLength(2);
+    const names = result.adapters.map((a) => a.name);
+    expect(names).toEqual(["replicate", "nano-banana"]);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("returns empty when no env vars set", () => {
+    vi.stubEnv("GEMINI_API_KEY", "");
+    vi.stubEnv("REPLICATE_API_TOKEN", "");
+
+    const result = createImageGenAdaptersFromEnv();
+
+    expect(result.adapters).toHaveLength(0);
+    expect(result.skipped).toHaveLength(2);
+  });
+
+  it("accepts per-adapter overrides alongside env keys", () => {
+    vi.stubEnv("GEMINI_API_KEY", "env-gem");
+    vi.stubEnv("REPLICATE_API_TOKEN", "");
+
+    const result = createImageGenAdaptersFromEnv({
+      nanoBanana: { costPerImage: 0.01 },
+    });
+
+    expect(result.adapters).toHaveLength(1);
+    expect(result.adapters[0].name).toBe("nano-banana");
+  });
+});

--- a/src/monetization/adapters/image-gen-factory.ts
+++ b/src/monetization/adapters/image-gen-factory.ts
@@ -1,0 +1,89 @@
+/**
+ * Image generation adapter factory — instantiates all available image-gen
+ * adapters from environment config and returns them ready to register.
+ *
+ * Only adapters with valid config are created. The factory never touches
+ * the database — it returns plain ProviderAdapter instances that the caller
+ * registers with an ArbitrageRouter or AdapterSocket.
+ *
+ * Priority order (cheapest first, when all adapters available):
+ *   self-hosted-sdxl (GPU, cheapest — not yet implemented)
+ *   → Replicate (~$0.019/image, SDXL on A40)
+ *   → Nano Banana / Gemini ($0.02/image)
+ */
+
+import { createNanoBananaAdapter, type NanoBananaAdapterConfig } from "./nano-banana.js";
+import { createReplicateAdapter, type ReplicateAdapterConfig } from "./replicate.js";
+import type { ProviderAdapter } from "./types.js";
+
+/** Top-level factory config. Only providers with an API key/token are instantiated. */
+export interface ImageGenFactoryConfig {
+  /** Gemini API key (for Nano Banana image generation). Omit or empty string to skip. */
+  geminiApiKey?: string;
+  /** Replicate API token. Omit or empty string to skip. */
+  replicateApiToken?: string;
+  /** Per-adapter config overrides */
+  nanoBanana?: Omit<Partial<NanoBananaAdapterConfig>, "apiKey">;
+  replicate?: Omit<Partial<ReplicateAdapterConfig>, "apiToken">;
+}
+
+/** Result of the factory — adapters + metadata for observability. */
+export interface ImageGenFactoryResult {
+  /** All instantiated adapters, ordered by cost priority (cheapest first). */
+  adapters: ProviderAdapter[];
+  /** Map of adapter name → ProviderAdapter for direct registration. */
+  adapterMap: Map<string, ProviderAdapter>;
+  /** Names of providers that were skipped (missing config). */
+  skipped: string[];
+}
+
+/**
+ * Create image generation adapters from the provided config.
+ *
+ * Returns only adapters whose API key/token is present and non-empty.
+ * Order matches arbitrage priority: cheapest first.
+ */
+export function createImageGenAdapters(config: ImageGenFactoryConfig): ImageGenFactoryResult {
+  const adapters: ProviderAdapter[] = [];
+  const skipped: string[] = [];
+
+  // Replicate — ~$0.019/image SDXL (cheapest)
+  if (config.replicateApiToken) {
+    adapters.push(createReplicateAdapter({ apiToken: config.replicateApiToken, ...config.replicate }));
+  } else {
+    skipped.push("replicate");
+  }
+
+  // Nano Banana (Gemini) — $0.02/image (slightly more expensive fallback)
+  if (config.geminiApiKey) {
+    adapters.push(createNanoBananaAdapter({ apiKey: config.geminiApiKey, ...config.nanoBanana }));
+  } else {
+    skipped.push("nano-banana");
+  }
+
+  const adapterMap = new Map<string, ProviderAdapter>();
+  for (const adapter of adapters) {
+    adapterMap.set(adapter.name, adapter);
+  }
+
+  return { adapters, adapterMap, skipped };
+}
+
+/**
+ * Create image generation adapters from environment variables.
+ *
+ * Reads config from:
+ *   - GEMINI_API_KEY (for Nano Banana)
+ *   - REPLICATE_API_TOKEN
+ *
+ * Accepts optional per-adapter overrides.
+ */
+export function createImageGenAdaptersFromEnv(
+  overrides?: Omit<ImageGenFactoryConfig, "geminiApiKey" | "replicateApiToken">,
+): ImageGenFactoryResult {
+  return createImageGenAdapters({
+    geminiApiKey: process.env.GEMINI_API_KEY,
+    replicateApiToken: process.env.REPLICATE_API_TOKEN,
+    ...overrides,
+  });
+}

--- a/src/monetization/adapters/rate-table.test.ts
+++ b/src/monetization/adapters/rate-table.test.ts
@@ -62,7 +62,9 @@ describe("RATE_TABLE", () => {
 
     for (const entry of premiumEntries) {
       // Third-party providers are well-known brand names
-      const isThirdParty = ["elevenlabs", "deepgram", "openrouter", "replicate", "gemini"].includes(entry.provider);
+      const isThirdParty = ["elevenlabs", "deepgram", "openrouter", "replicate", "nano-banana"].includes(
+        entry.provider,
+      );
       expect(isThirdParty).toBe(true);
     }
   });
@@ -146,7 +148,7 @@ describe("getRatesForCapability", () => {
   });
 
   it("returns empty array for non-existent capability", () => {
-    const rates = getRatesForCapability("image-generation" as unknown as AdapterCapability);
+    const rates = getRatesForCapability("video-generation" as unknown as AdapterCapability);
     expect(rates).toHaveLength(0);
   });
 

--- a/src/monetization/adapters/rate-table.ts
+++ b/src/monetization/adapters/rate-table.ts
@@ -109,10 +109,34 @@ export const RATE_TABLE: RateEntry[] = [
     effectivePrice: 0.000000026, // = costPerUnit * margin ($0.026 per 1M tokens)
   },
 
+  // Image Generation
+  // NOTE: No self-hosted SDXL adapter yet — only premium tiers available.
+  // When self-hosted-sdxl lands, add a standard tier entry here.
+  // Multiple premium providers exist — cheapest first so lookupRate() returns
+  // the best rate. Use getRatesForCapability() for per-provider breakdowns.
+  {
+    capability: "image-generation",
+    tier: "premium",
+    provider: "replicate",
+    costPerUnit: 0.019, // ~$0.019 per image (SDXL on A40, ~8s avg at $0.0023/s)
+    billingUnit: "per-image",
+    margin: 1.3, // 30% — dashboard default; runtime uses getMargin()
+    effectivePrice: 0.0247, // = costPerUnit * margin ($24.70 per 1K images)
+  },
+  {
+    capability: "image-generation",
+    tier: "premium",
+    provider: "nano-banana",
+    costPerUnit: 0.02, // $0.02 per image (Gemini Imagen via Nano Banana)
+    billingUnit: "per-image",
+    margin: 1.3, // 30% — dashboard default; runtime uses getMargin()
+    effectivePrice: 0.026, // = costPerUnit * margin ($26.00 per 1K images)
+  },
+
   // Future self-hosted adapters will add more entries here:
   // - transcription: self-hosted-whisper (standard) — when GPU adapter exists
   // - embeddings: self-hosted-embeddings (standard) — when GPU adapter exists
-  // - image-generation: self-hosted-sdxl (standard) vs replicate (premium)
+  // - image-generation: self-hosted-sdxl (standard) — when GPU adapter exists
 ];
 
 /**

--- a/src/monetization/index.ts
+++ b/src/monetization/index.ts
@@ -42,6 +42,13 @@ export {
   type EmbeddingsFactoryResult,
 } from "./adapters/embeddings-factory.js";
 export { createGeminiAdapter, type GeminiAdapterConfig } from "./adapters/gemini.js";
+// Image-generation adapter factory (WOP-2188)
+export {
+  createImageGenAdapters,
+  createImageGenAdaptersFromEnv,
+  type ImageGenFactoryConfig,
+  type ImageGenFactoryResult,
+} from "./adapters/image-gen-factory.js";
 export { createKimiAdapter, type KimiAdapterConfig } from "./adapters/kimi.js";
 // Margin config (WOP-364)
 export {


### PR DESCRIPTION
## Summary
- Add `createImageGenAdapters()` and `createImageGenAdaptersFromEnv()` — wires nano-banana (Gemini, $0.02/image) and replicate (SDXL, ~$0.019/image) in cost-priority order
- Add image-generation entries to `RATE_TABLE` (both premium tier — no self-hosted SDXL yet)
- Export factory types and functions from `src/monetization/index.ts`
- 14 new tests for factory behavior, 2 rate table test updates for new entries

Follows the same factory pattern as TTS, transcription, and text-gen factories.

## Test plan
- [x] All 14 image-gen factory tests pass (adapters, priority order, skip logic, env vars, overrides)
- [x] All 24 rate table tests pass (updated for new image-generation entries)
- [x] `pnpm lint && pnpm format && pnpm build` clean

Closes WOP-2188

## Summary by Sourcery

Introduce an image-generation adapter factory and wire new providers into monetization pricing.

New Features:
- Add an image-generation adapter factory that instantiates Nano Banana (Gemini) and Replicate adapters with cost-based priority.
- Expose image-generation factory functions and types from the monetization public API.
- Add premium-tier image-generation entries for Nano Banana and Replicate to the monetization rate table.

Enhancements:
- Extend rate table provider classification to recognize Nano Banana as a third-party premium provider.

Tests:
- Add a dedicated test suite for the image-generation adapter factory covering config, priority order, and env-based creation.
- Update rate table tests to account for the new image-generation providers and to validate behavior for an unknown capability.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add image generation adapter factory with Replicate and Nano Banana providers
> - Adds [`createImageGenAdapters`](https://github.com/wopr-network/platform-core/pull/27/files#diff-5cfb034357a4a595748e4aaf52455bfaa76eb39630285f82055f2abf57e241e6) and `createImageGenAdaptersFromEnv` to instantiate image-generation adapters based on available credentials, returning adapters ordered cheapest-first (Replicate before Nano Banana).
> - Adds `image-generation` entries to [`RATE_TABLE`](https://github.com/wopr-network/platform-core/pull/27/files#diff-98b8ee273a5dd20062357a4b70d1c168d8fdcaf8778f1f0536f1232ef45ebc60) for both providers with per-image billing at 1.3x margin.
> - Exports factory types and functions from the monetization package entrypoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 056e08e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image generation adapter factory to manage multiple providers
  * Support for replicate and nano-banana providers
  * Configurable via environment variables or config objects
  * Added premium pricing rates for image generation

* **Tests**
  * Comprehensive tests for adapter factory covering ordering, skipping, overrides, env-based creation, and adapter mapping
  * Updated rate-table tests to reflect provider changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->