### PR TITLE
feat: wire image-gen factory into unified bootstrap

### DIFF
--- a/src/monetization/adapters/bootstrap.test.ts
+++ b/src/monetization/adapters/bootstrap.test.ts
@@ -21,11 +21,15 @@ describe("bootstrapAdapters", () => {
       embeddings: {
         openrouterApiKey: "sk-or",
       },
+      imageGen: {
+        replicateApiToken: "r8-rep",
+        geminiApiKey: "sk-gem",
+      },
     });
 
-    // 5 text-gen + 2 TTS + 1 transcription + 1 embeddings = 9
-    expect(result.adapters).toHaveLength(9);
-    expect(result.summary.total).toBe(9);
+    // 5 text-gen + 2 TTS + 1 transcription + 1 embeddings + 2 image-gen = 11
+    expect(result.adapters).toHaveLength(11);
+    expect(result.summary.total).toBe(11);
     expect(result.summary.skipped).toBe(0);
   });
 
@@ -54,6 +58,7 @@ describe("bootstrapAdapters", () => {
       tts: 1,
       transcription: 1,
       embeddings: 1,
+      "image-generation": 0,
     });
   });
 
@@ -69,6 +74,7 @@ describe("bootstrapAdapters", () => {
     expect(result.skipped.transcription).toEqual(["deepgram"]);
     expect(result.skipped.embeddings).toEqual(["openrouter"]);
     expect(result.skipped["text-generation"]).toEqual(["gemini", "minimax", "kimi", "openrouter"]);
+    expect(result.skipped["image-generation"]).toEqual(["replicate", "nano-banana"]);
   });
 
   it("returns empty result when no config provided", () => {
@@ -96,6 +102,7 @@ describe("bootstrapAdapters", () => {
     expect(result.summary.byCapability.tts).toBe(0);
     expect(result.summary.byCapability.transcription).toBe(0);
     expect(result.summary.byCapability.embeddings).toBe(0);
+    expect(result.summary.byCapability["image-generation"]).toBe(0);
   });
 
   it("passes per-adapter overrides through", () => {
@@ -129,12 +136,14 @@ describe("bootstrapAdaptersFromEnv", () => {
     vi.stubEnv("CHATTERBOX_BASE_URL", "http://chatterbox:8000");
     vi.stubEnv("ELEVENLABS_API_KEY", "env-el");
     vi.stubEnv("DEEPGRAM_API_KEY", "env-dg");
+    vi.stubEnv("REPLICATE_API_TOKEN", "r8-rep");
+    vi.stubEnv("NANO_BANANA_API_KEY", "env-nb");
 
     const result = bootstrapAdaptersFromEnv();
 
-    // 5 text-gen + 2 TTS + 1 transcription + 1 embeddings = 9
-    expect(result.adapters).toHaveLength(9);
-    expect(result.summary.total).toBe(9);
+    // 5 text-gen + 2 TTS + 1 transcription + 1 embeddings + 2 image-gen = 11
+    expect(result.adapters).toHaveLength(11);
+    expect(result.summary.total).toBe(11);
   });
 
   it("returns empty when no env vars set", () => {
@@ -146,6 +155,8 @@ describe("bootstrapAdaptersFromEnv", () => {
     vi.stubEnv("CHATTERBOX_BASE_URL", "");
     vi.stubEnv("ELEVENLABS_API_KEY", "");
     vi.stubEnv("DEEPGRAM_API_KEY", "");
+    vi.stubEnv("REPLICATE_API_TOKEN", "");
+    vi.stubEnv("NANO_BANANA_API_KEY", "");
 
     const result = bootstrapAdaptersFromEnv();
 
@@ -162,6 +173,8 @@ describe("bootstrapAdaptersFromEnv", () => {
     vi.stubEnv("CHATTERBOX_BASE_URL", "");
     vi.stubEnv("ELEVENLABS_API_KEY", "");
     vi.stubEnv("DEEPGRAM_API_KEY", "");
+    vi.stubEnv("REPLICATE_API_TOKEN", "");
+    vi.stubEnv("NANO_BANANA_API_KEY", "");
 
     const result = bootstrapAdaptersFromEnv({
       textGen: { deepseek: { marginMultiplier: 2.0 } },

--- a/src/monetization/adapters/bootstrap.ts
+++ b/src/monetization/adapters/bootstrap.ts
@@ -12,12 +12,11 @@
  *   - tts (Chatterbox GPU, ElevenLabs)
  *   - transcription (Deepgram)
  *   - embeddings (OpenRouter)
- *
- * Image-generation (Nano Banana, Replicate) will be wired once the
- * image-gen-factory PR merges.
+ *   - image-generation (Replicate, Nano Banana)
  */
 
 import { createEmbeddingsAdapters, type EmbeddingsFactoryConfig } from "./embeddings-factory.js";
+import { createImageGenAdapters, type ImageGenFactoryConfig } from "./image-gen-factory.js";
 import { createTextGenAdapters, type TextGenFactoryConfig } from "./text-gen-factory.js";
 import { createTranscriptionAdapters, type TranscriptionFactoryConfig } from "./transcription-factory.js";
 import { createTTSAdapters, type TTSFactoryConfig } from "./tts-factory.js";
@@ -33,6 +32,8 @@ export interface BootstrapConfig {
   transcription?: TranscriptionFactoryConfig;
   /** Embeddings adapter config */
   embeddings?: EmbeddingsFactoryConfig;
+  /** Image generation adapter config */
+  imageGen?: ImageGenFactoryConfig;
 }
 
 /** Result of bootstrapping all adapters. */
@@ -45,6 +46,12 @@ export interface BootstrapResult {
    * capabilities (e.g. OpenRouter for both text-gen and embeddings). Each
    * instance is independently configured. Use the per-capability factory
    * results if you need a name→adapter map within a single capability.
+   *
+   * NOTE: Some adapters advertise more capabilities than the factory that
+   * created them (e.g. Replicate advertises text-generation and transcription
+   * in addition to image-generation). The ArbitrageRouter should use the
+   * factory-assigned capability (reflected in byCapability), not the adapter's
+   * own capabilities array, for routing decisions.
    */
   adapters: ProviderAdapter[];
   /** Names of providers that were skipped (missing config), grouped by capability. */
@@ -68,12 +75,14 @@ export function bootstrapAdapters(config: BootstrapConfig): BootstrapResult {
   const tts = createTTSAdapters(config.tts ?? {});
   const transcription = createTranscriptionAdapters(config.transcription ?? {});
   const embeddings = createEmbeddingsAdapters(config.embeddings ?? {});
+  const imageGen = createImageGenAdapters(config.imageGen ?? {});
 
   const adapters: ProviderAdapter[] = [
     ...textGen.adapters,
     ...tts.adapters,
     ...transcription.adapters,
     ...embeddings.adapters,
+    ...imageGen.adapters,
   ];
 
   const skipped: Record<string, string[]> = {};
@@ -81,6 +90,7 @@ export function bootstrapAdapters(config: BootstrapConfig): BootstrapResult {
   if (tts.skipped.length > 0) skipped.tts = tts.skipped;
   if (transcription.skipped.length > 0) skipped.transcription = transcription.skipped;
   if (embeddings.skipped.length > 0) skipped.embeddings = embeddings.skipped;
+  if (imageGen.skipped.length > 0) skipped["image-generation"] = imageGen.skipped;
 
   let totalSkipped = 0;
   for (const list of Object.values(skipped)) {
@@ -98,6 +108,7 @@ export function bootstrapAdapters(config: BootstrapConfig): BootstrapResult {
         tts: tts.adapters.length,
         transcription: transcription.adapters.length,
         embeddings: embeddings.adapters.length,
+        "image-generation": imageGen.adapters.length,
       },
     },
   };
@@ -111,6 +122,7 @@ export function bootstrapAdapters(config: BootstrapConfig): BootstrapResult {
  *   - CHATTERBOX_BASE_URL, ELEVENLABS_API_KEY (TTS)
  *   - DEEPGRAM_API_KEY (transcription)
  *   - OPENROUTER_API_KEY (embeddings)
+ *   - REPLICATE_API_TOKEN, NANO_BANANA_API_KEY (image-gen)
  *
  * Accepts optional per-capability config overrides.
  */
@@ -136,6 +148,13 @@ export function bootstrapAdaptersFromEnv(overrides?: Partial<BootstrapConfig>): 
     embeddings: {
       openrouterApiKey: process.env.OPENROUTER_API_KEY,
       ...overrides?.embeddings,
+    },
+    imageGen: {
+      replicateApiToken: process.env.REPLICATE_API_TOKEN,
+      // Separate env var from GEMINI_API_KEY (used for text-gen) to avoid
+      // silently enabling image-gen when only text-gen is intended.
+      geminiApiKey: process.env.NANO_BANANA_API_KEY,
+      ...overrides?.imageGen,
     },
   });
 }


### PR DESCRIPTION
## Summary
- Wires `createImageGenAdapters` (Replicate, Nano Banana) into the unified `bootstrapAdapters()` function
- Adds `imageGen` config to `BootstrapConfig` and `bootstrapAdaptersFromEnv()`
- Reads `REPLICATE_API_TOKEN` and `GEMINI_API_KEY` env vars for image-gen
- Updates all bootstrap tests for the new capability (9 → 11 total adapters)

Completes the arbitrage stack: all 5 capabilities now bootstrap from a single config.

## Test plan
- [x] All 11 bootstrap tests pass
- [x] Lint, format, build clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate image generation into the unified adapter bootstrap flow and extend environment-driven configuration to cover the new capability.

New Features:
- Add image generation support to the unified adapter bootstrap via a new imageGen capability in BootstrapConfig.
- Allow bootstrapping image generation adapters from environment variables including REPLICATE_API_TOKEN and GEMINI_API_KEY.

Enhancements:
- Include image-generation counts and skipped adapters in bootstrap summaries and reporting.
- Update bootstrap-from-env and configuration tests to cover the new image generation capability and increased adapter total.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire image-generation adapters into unified bootstrap
> - Integrates `createImageGenAdapters` into [`bootstrap.ts`](https://github.com/wopr-network/platform-core/pull/31/files#diff-02f1407cdb143bfcb4fb1b13ec172453c9c58846984e58af9e9f569e15f3e49a), adding an optional `imageGen` field to `BootstrapConfig`.
> - `bootstrapAdapters` now calls the image-gen factory, merges resulting adapters into the returned array, and tracks skipped providers (`replicate`, `nano-banana`) under the `image-generation` capability key.
> - `bootstrapAdaptersFromEnv` reads `REPLICATE_API_TOKEN` and `NANO_BANANA_API_KEY` from `process.env` to activate image-generation adapters, with optional override support.
> - Expected adapter count increases from 9 to 11 when all keys are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca5461d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image generation capability support to the adapter system.
  * Extended configuration to accept image generation API credentials (Replicate and Gemini).
  * Environment variable support for automatic image generation adapter setup.
  * Updated metrics and reporting to include image generation adapter statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->