### PR TITLE
fix: cast now() to text for PGlite compatibility

### DIFF
--- a/src/account/deletion-executor-repository.ts
+++ b/src/account/deletion-executor-repository.ts
@@ -93,7 +93,7 @@ export class DrizzleDeletionExecutorRepository implements IDeletionExecutorRepos
       .update(accountDeletionRequests)
       .set({
         status: "completed",
-        completedAt: sql`now()`,
+        completedAt: sql`now()::text`,
         deletionSummary,
         updatedAt: sql`now()`,
       })

--- a/src/account/deletion-repository.ts
+++ b/src/account/deletion-repository.ts
@@ -85,7 +85,7 @@ export class DrizzleDeletionRepository implements IDeletionRepository {
       .update(accountDeletionRequests)
       .set({
         status: "completed",
-        completedAt: sql`now()`,
+        completedAt: sql`now()::text`,
         deletionSummary: summary,
         updatedAt: sql`now()`,
       })
@@ -96,7 +96,9 @@ export class DrizzleDeletionRepository implements IDeletionRepository {
     const rows = await this.db
       .select()
       .from(accountDeletionRequests)
-      .where(and(eq(accountDeletionRequests.status, "pending"), lte(accountDeletionRequests.deleteAfter, sql`now()`)));
+      .where(
+        and(eq(accountDeletionRequests.status, "pending"), lte(accountDeletionRequests.deleteAfter, sql`now()::text`)),
+      );
     return rows.map(toRow);
   }
 


### PR DESCRIPTION
## Summary
- `delete_after` and `completed_at` are text columns, but `now()` returns `timestamptz`
- PGlite (used in unit tests) rejects the implicit cast that PostgreSQL would allow
- Cast `now()::text` in `findExpired`, `markCompleted` (both repos)

## Test plan
- [x] All 31 account tests pass locally

## Summary by Sourcery

Bug Fixes:
- Fix account deletion completion and expiration queries by casting now() to text to match text-typed timestamp columns and avoid PGlite implicit cast errors.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cast `now()` to text in deletion repository SQL for PGlite compatibility
> PGlite does not handle raw `now()` timestamp expressions in SQL assignments and comparisons. This change casts `now()` to `::text` in `markCompleted` (both [deletion-executor-repository.ts](https://github.com/wopr-network/platform-core/pull/33/files#diff-437dcaf53443fced8f74704eff963b39a31d14971e35a1cdd14b35a907952aa4) and [deletion-repository.ts](https://github.com/wopr-network/platform-core/pull/33/files#diff-30764b3396dd151ae4cc35ce4100a7bf75b0f833848563d500f26c3994cbaaa0)) and in the `findExpired` date comparison in `deletion-repository.ts`. Behavioral Change: `completedAt` and expiry comparisons now use text-cast timestamps instead of native timestamp values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77e41a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->