### PR TITLE
fix: check cause and message for PG 42P01 error code

### DIFF
--- a/src/account/deletion-executor-repository.ts
+++ b/src/account/deletion-executor-repository.ts
@@ -144,8 +144,12 @@ export class DrizzleDeletionExecutorRepository implements IDeletionExecutorRepos
       const result = await this.db.execute(sql`DELETE FROM credit_adjustments WHERE tenant_id = ${tenantId}`);
       return (result as unknown as { rowCount?: number }).rowCount ?? 0;
     } catch (err: unknown) {
-      const pgCode = (err as { code?: string }).code;
+      // Drizzle may wrap PGlite errors; check both top-level and cause for the PG code
+      const errObj = err as { code?: string; cause?: { code?: string }; message?: string };
+      const pgCode = errObj.code ?? errObj.cause?.code;
       if (pgCode === "42P01") return null; // table does not exist
+      // PGlite errors surfaced through Drizzle may embed the code in the message
+      if (errObj.message?.includes("42P01")) return null;
       throw err;
     }
   }


### PR DESCRIPTION
## Summary
- Drizzle wraps PGlite errors, so `err.code` may not contain the PG error code
- Also check `err.cause.code` and `err.message` for "42P01" (table does not exist)
- Prevents `deleteCreditAdjustments` from throwing in environments where `credit_adjustments` table doesn't exist

## Test plan
- [x] All 31 account tests pass locally

## Summary by Sourcery

Bug Fixes:
- Ensure deletion of credit adjustments treats wrapped PostgreSQL 42P01 (table does not exist) errors as a null result instead of throwing, including when the code only appears on the cause or in the error message.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `deleteCreditAdjustments` to detect PG 42P01 error in wrapped cause and message
> Drizzle can wrap PGlite errors, so the `42P01` (undefined table) code may appear on `err.cause.code` or within `err.message` rather than directly on `err.code`. The fix in [deletion-executor-repository.ts](https://github.com/wopr-network/platform-core/pull/34/files#diff-437dcaf53443fced8f74704eff963b39a31d14971e35a1cdd14b35a907952aa4) checks all three locations and returns `null` (table missing) in any matching case instead of rethrowing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c82140.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->