### PR TITLE
fix: use pull_request_target for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,11 +1,10 @@
 name: Dependabot Auto-Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
   auto-merge:
     uses: wopr-network/.github/.github/workflows/dependabot-auto-merge.yml@main
     secrets: inherit
-


### PR DESCRIPTION
## Summary
- Changes dependabot auto-merge trigger from `pull_request` to `pull_request_target`
- Fixes `startup_failure` on every dependabot PR caused by self-hosted runner restrictions on reusable workflows triggered by dependabot

## Root cause
GitHub blocks dependabot-triggered `pull_request` events from running reusable workflows on self-hosted runners. `pull_request_target` runs in the base branch context with full permissions, bypassing this restriction.

## Test plan
- [x] Verify existing dependabot PRs get auto-merged after this lands

## Summary by Sourcery

CI:
- Update Dependabot auto-merge workflow trigger from pull_request to pull_request_target to avoid self-hosted runner restrictions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Dependabot auto-merge workflow to use `pull_request_target` trigger
> Changes the trigger in [dependabot-auto-merge.yml](.github/workflows/dependabot-auto-merge.yml) from `pull_request` to `pull_request_target`. Dependabot PRs run with limited token permissions under `pull_request`, causing the auto-merge workflow to fail; `pull_request_target` grants the necessary write access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b0eeb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->