### PR TITLE
fix: inline dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,5 +6,49 @@ on:
 
 jobs:
   auto-merge:
-    uses: wopr-network/.github/.github/workflows/dependabot-auto-merge.yml@main
-    secrets: inherit
+    runs-on: [self-hosted, Linux, X64]
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Get PR metadata
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) { core.setOutput('skip', 'true'); return; }
+
+            const { data: details } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            // Only auto-merge patch and minor updates (not major)
+            const title = details.title;
+            const isMajor = /from \d+ to \d+/.test(title) &&
+              title.match(/from (\d+)/)?.[ 1] !== title.match(/to (\d+)/)?.[ 1];
+
+            core.setOutput('skip', isMajor ? 'true' : 'false');
+            core.setOutput('pr_number', String(pr.number));
+
+      - name: Approve PR
+        if: steps.meta.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt('${{ steps.meta.outputs.pr_number }}'),
+              event: 'APPROVE',
+            });
+
+      - name: Enable auto-merge
+        if: steps.meta.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr merge --auto --squash ${{ steps.meta.outputs.pr_number }} || true


### PR DESCRIPTION
## Summary
- Inlines the dependabot auto-merge job instead of calling a reusable workflow
- Fixes: `pull_request_target` cannot call reusable workflows cross-repo

## Root cause
GitHub does not allow `pull_request_target` events to dispatch reusable workflows from other repositories. The job must be inlined.

## Summary by Sourcery

Enhancements:
- Inline the Dependabot auto-merge job with logic to approve and auto-merge eligible PRs while skipping major version upgrades.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Inline dependabot auto-merge workflow instead of using a reusable workflow
> Replaces the reusable workflow call in [dependabot-auto-merge.yml](.github/workflows/dependabot-auto-merge.yml) with a self-contained inline job.
>
> - Runs on a self-hosted Linux X64 runner, gated to `dependabot[bot]` actors only
> - Parses the PR title for `from X to Y` version strings and skips auto-merge for major version bumps
> - Approves qualifying PRs via the GitHub API and enables squash auto-merge via `gh pr merge --auto --squash`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf2eb5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->