### PR TITLE
fix: major-version detection in dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -54,4 +54,4 @@ jobs:
         if: steps.meta.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr merge --auto --squash ${{ steps.meta.outputs.pr_number }}
+        run: gh pr merge --auto --squash ${{ steps.meta.outputs.pr_number }} --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Fix broken semver regex that caused major version bumps to be auto-merged
- Replace `|| true` with `continue-on-error: true` for visible failure logging

## Root cause
The regex `/from \d+ to \d+/` never matches semver titles like "Bump foo from 1.2.3 to 2.0.0" because `\d+` stops at the dot. Result: `isMajor` was always `false`, all bumps including major were auto-merged.

## Fix
Extract major version with `/from (\d+)\.\d/` and `/to (\d+)\.\d/`, compare those.

Flagged by: Devin, Greptile, Copilot, Sourcery

## Summary by Sourcery

Correct major-version detection in Dependabot auto-merge workflow and improve error visibility when enabling auto-merge.

Bug Fixes:
- Ensure Dependabot auto-merge skips pull requests that bump dependencies across major versions by correctly parsing semver titles.

Enhancements:
- Configure the auto-merge step to continue on error instead of suppressing failures with shell-level fallbacks, making merge issues visible in workflow logs.

CI:
- Adjust Dependabot auto-merge GitHub Actions workflow logic for version comparison and error handling.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix major-version detection in dependabot auto-merge workflow
> - Replaces the major-version detection regex in [dependabot-auto-merge.yml](.github/workflows/dependabot-auto-merge.yml) to extract explicit major components from `from X.` and `to X.` patterns, setting `isMajor` only when both are present and differ — previously, titles not matching the old pattern could be incorrectly flagged.
> - Adds `--repo ${{ github.repository }}` to the `gh pr merge` command and removes the `|| true` fallback, so merge failures now fail the job rather than being silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ceb197.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->