### PR TITLE
fix: narrow migration catch to module-not-found errors only

### DIFF
--- a/src/auth/better-auth.ts
+++ b/src/auth/better-auth.ts
@@ -268,7 +268,10 @@ export async function runAuthMigrations(): Promise<void> {
   let getMigrations: DbModule["getMigrations"];
   try {
     ({ getMigrations } = (await import("better-auth/db/migration")) as unknown as DbModule);
-  } catch {
+  } catch (err: unknown) {
+    // Only fall back if the module path doesn't exist (ERR_MODULE_NOT_FOUND / ERR_PACKAGE_PATH_NOT_EXPORTED)
+    const code = (err as { code?: string }).code;
+    if (code !== "ERR_MODULE_NOT_FOUND" && code !== "ERR_PACKAGE_PATH_NOT_EXPORTED") throw err;
     ({ getMigrations } = (await import("better-auth/db")) as unknown as DbModule);
   }
   const { runMigrations } = await getMigrations(authOptions(_config));


### PR DESCRIPTION
## Summary
Follow-up to #44. Narrows the bare `catch` to only catch `ERR_MODULE_NOT_FOUND` and `ERR_PACKAGE_PATH_NOT_EXPORTED` — re-throws all other errors instead of silently swallowing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Avoid silently swallowing non-module-not-found errors when importing the auth migrations module by only falling back on specific missing-module error codes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Narrow migration import fallback in `runAuthMigrations` to module-not-found errors only
> Previously, any error during `import('better-auth/db/migration')` would silently fall back to `better-auth/db`. Now the catch clause inspects the error's `code` property and only falls back for `ERR_MODULE_NOT_FOUND` or `ERR_PACKAGE_PATH_NOT_EXPORTED`; all other errors are rethrown. Risk: errors that were previously swallowed (e.g. syntax errors in the migration module) will now surface as uncaught exceptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca86ed2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->