### PR TITLE
fix: add debug-level logging to silenced catch blocks (WOP-2131)

### DIFF
--- a/src/api/routes/admin-onboarding.ts
+++ b/src/api/routes/admin-onboarding.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { AuthEnv } from "../../auth/index.js";
+import { logger } from "../../config/logger.js";
 import type { IOnboardingScriptRepository } from "../../onboarding/drizzle-onboarding-script-repository.js";
 import type { AdminAuditLogger } from "./admin-audit-helper.js";
 import { safeAuditLog } from "./admin-audit-helper.js";
@@ -31,7 +32,8 @@ export function createAdminOnboardingRoutes(getRepo: RepoFactory, auditLogger?: 
     let body: Record<string, unknown>;
     try {
       body = (await c.req.json()) as Record<string, unknown>;
-    } catch {
+    } catch (err: unknown) {
+      logger.debug("Failed to parse onboarding script JSON body", { error: err });
       return c.json({ error: "Invalid JSON body" }, 400);
     }
 

--- a/src/dht/bootstrap-manager.test.ts
+++ b/src/dht/bootstrap-manager.test.ts
@@ -115,6 +115,22 @@ describe("DhtBootstrapManager", () => {
       expect(docker.createVolume).toHaveBeenCalledWith({ Name: `${DHT_VOLUME_PREFIX}0` });
     });
 
+    it("logs at debug level when volume inspect fails", async () => {
+      const { logger } = await import("../config/logger.js");
+      const debugSpy = vi.spyOn(logger, "debug");
+      docker._volume.inspect.mockRejectedValue(new Error("no such volume"));
+      const container = mockContainer("c-0", `${DHT_CONTAINER_PREFIX}0`);
+      docker.createContainer.mockResolvedValue(container);
+
+      await manager.ensureNode(0);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Volume inspect failed"),
+        expect.objectContaining({ error: expect.any(Error) }),
+      );
+      debugSpy.mockRestore();
+    });
+
     it("passes DHT_PEERS env excluding self", async () => {
       const container = mockContainer("c-1", `${DHT_CONTAINER_PREFIX}1`);
       docker.createContainer.mockResolvedValue(container);

--- a/src/dht/bootstrap-manager.ts
+++ b/src/dht/bootstrap-manager.ts
@@ -257,7 +257,8 @@ export class DhtBootstrapManager {
     try {
       const volume = this.docker.getVolume(name);
       await volume.inspect();
-    } catch (_inspectErr: unknown) {
+    } catch (inspectErr: unknown) {
+      logger.debug(`Volume inspect failed for ${name}, will attempt to create`, { error: inspectErr });
       try {
         await this.docker.createVolume({ Name: name });
         logger.info(`Created DHT state volume ${name}`);


### PR DESCRIPTION
## Summary
Closes WOP-2131

- `admin-onboarding.ts`: Added logger import, bound bare `catch {}` variable as `catch (err: unknown)`, and added `logger.debug` call so JSON parse failures are visible in observability tooling
- `bootstrap-manager.ts`: Renamed `_inspectErr` → `inspectErr` (removing unused prefix) and added `logger.debug` log before the volume create attempt, surfacing Docker inspect failures at debug level
- `bootstrap-manager.test.ts`: Added test verifying `logger.debug` is called with the error when volume inspect fails

## Test plan
- [x] `npx vitest run src/dht/bootstrap-manager.test.ts` — 21 tests pass
- [x] `npx biome check src/` — no warnings or errors
- [x] `npx tsc --noEmit` — no type errors

Generated with Claude Code

## Summary by Sourcery

Add debug-level logging for previously silent error paths in onboarding and DHT bootstrap flows.

Bug Fixes:
- Log JSON parse failures in admin onboarding requests at debug level instead of silently swallowing them.
- Log Docker volume inspect failures at debug level before attempting volume creation.

Tests:
- Add a unit test ensuring volume inspect failures trigger a debug-level log with the associated error.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add debug-level logging to silenced catch blocks in admin onboarding and DHT bootstrap
> - Adds a debug log in [admin-onboarding.ts](https://github.com/wopr-network/platform-core/pull/46/files#diff-6b810be58073d71ffc108679d55a26bef37173b097157ab28c2e2f3ec5aca98f) when request body JSON parsing fails in the POST handler, before returning a 400 response.
> - Adds a debug log in [bootstrap-manager.ts](https://github.com/wopr-network/platform-core/pull/46/files#diff-7be5103686e4c2032422463fe2e42827fc2418ae7a0779a3cd294828b94d9152) when `volume.inspect()` fails in `DhtBootstrapManager.ensureVolume`, before attempting to create the volume.
> - Adds a test in [bootstrap-manager.test.ts](https://github.com/wopr-network/platform-core/pull/46/files#diff-ad29817c09c7fbbb85a1946eab38aecb9251a02c224fc364c90478194c6dde86) verifying the new debug log fires with the correct message and error metadata.
> - HTTP responses and functional behavior are unchanged in both cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 538bd57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->