### PR TITLE
fix: derive postmortem action item due dates from incident data (WOP-2127)

### DIFF
--- a/src/monetization/incident/postmortem.test.ts
+++ b/src/monetization/incident/postmortem.test.ts
@@ -121,4 +121,51 @@ describe("generatePostMortemTemplate", () => {
     expect(report.sections.actionItems).not.toContain("TODO");
     expect(report.sections.lessonsLearned).not.toContain("TODO");
   });
+
+  it("action items derive due dates from resolvedAt for resolved incidents", () => {
+    const report = generatePostMortemTemplate(
+      makeIncident({
+        resolvedAt: new Date("2026-01-15T13:00:00Z"),
+        severity: "SEV1",
+      }),
+    );
+    // SEV1: 7-day offset from resolvedAt → 2026-01-22
+    expect(report.sections.actionItems).toContain("2026-01-22");
+    expect(report.sections.actionItems).not.toContain("TBD");
+  });
+
+  it("action items derive due dates from startedAt for ongoing incidents", () => {
+    const report = generatePostMortemTemplate(
+      makeIncident({
+        resolvedAt: null,
+        startedAt: new Date("2026-01-15T12:00:00Z"),
+        severity: "SEV1",
+      }),
+    );
+    // SEV1: 7-day offset from startedAt → 2026-01-22
+    expect(report.sections.actionItems).toContain("2026-01-22");
+    expect(report.sections.actionItems).not.toContain("TBD");
+  });
+
+  it("SEV2 action items use 14-day offset", () => {
+    const report = generatePostMortemTemplate(
+      makeIncident({
+        resolvedAt: new Date("2026-01-15T13:00:00Z"),
+        severity: "SEV2",
+      }),
+    );
+    // SEV2: 14-day offset from resolvedAt → 2026-01-29
+    expect(report.sections.actionItems).toContain("2026-01-29");
+  });
+
+  it("SEV3 action items use 14-day offset", () => {
+    const report = generatePostMortemTemplate(
+      makeIncident({
+        resolvedAt: new Date("2026-01-15T13:00:00Z"),
+        severity: "SEV3",
+      }),
+    );
+    // SEV3: 14-day offset from resolvedAt → 2026-01-29
+    expect(report.sections.actionItems).toContain("2026-01-29");
+  });
 });

--- a/src/monetization/incident/postmortem.ts
+++ b/src/monetization/incident/postmortem.ts
@@ -79,8 +79,8 @@ _[PENDING: Describe what fixed the issue and how service was restored.]_`,
     actionItems: `| Action | Owner | Due Date | Priority |
 |--------|-------|----------|----------|
 | _[PENDING: Add action item]_ | _[PENDING: Owner]_ | _[PENDING: Date]_ | P1 |
-| Improve detection alert thresholds | on-call-engineer | TBD | P2 |
-| Add runbook link to alert notification | on-call-engineer | TBD | P2 |`,
+| Improve detection alert thresholds | on-call-engineer | ${actionItemDueDate(incident)} | P2 |
+| Add runbook link to alert notification | on-call-engineer | ${actionItemDueDate(incident)} | P2 |`,
 
     lessonsLearned: `**What went well:**
 - _[PENDING: What worked well in detection and response?]_
@@ -164,4 +164,11 @@ function formatDuration(ms: number): string {
   if (hours === 0) return `${minutes}m`;
   if (remainingMinutes === 0) return `${hours}h`;
   return `${hours}h ${remainingMinutes}m`;
+}
+
+function actionItemDueDate(incident: IncidentSummary): string {
+  const base = incident.resolvedAt ?? incident.startedAt;
+  const offsetDays = incident.severity === "SEV1" ? 7 : 14;
+  const due = new Date(base.getTime() + offsetDays * 24 * 60 * 60 * 1000);
+  return due.toISOString().split("T")[0];
 }


### PR DESCRIPTION
## Summary
Closes WOP-2127

- Replace hardcoded `TBD` due dates in postmortem action item template with dates derived from incident data
- Add `actionItemDueDate()` helper: SEV1 gets 7-day offset, SEV2/SEV3 get 14-day offset from `resolvedAt` (or `startedAt` for ongoing incidents)
- The `TBD` for `revenueImpactCents === null` in the summary section is unchanged — that TBD means "revenue impact not yet calculated"

## Test plan
- [x] 4 new tests added covering SEV1/SEV2/SEV3 and ongoing incident cases
- [x] All 19 tests pass (`npx vitest run src/monetization/incident/postmortem.test.ts`)
- [x] `npm run check` passes (biome + tsc)
- [x] Existing "summary shows TBD when revenueImpactCents is null" test still passes

Generated with Claude Code

## Summary by Sourcery

Derive postmortem action item due dates from incident data instead of using hardcoded placeholders.

New Features:
- Introduce an actionItemDueDate helper that calculates postmortem action item due dates based on incident severity and timestamps.

Bug Fixes:
- Ensure postmortem action items no longer display placeholder TBD due dates when incident timing data is available.

Tests:
- Add unit tests covering due date derivation for SEV1, SEV2, SEV3, and ongoing incidents using startedAt when resolvedAt is null.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive postmortem action item due dates from incident resolvedAt/startedAt and severity
> Replaces hardcoded `TBD` due dates in the postmortem template with computed dates from incident data. A new `actionItemDueDate` helper in [postmortem.ts](https://github.com/wopr-network/platform-core/pull/47/files#diff-72fbab55544a6a320c10b41e3efba89dad0f7a7c45b3ee93f4c30bd8a2e7e3f5) picks `resolvedAt` if available, otherwise `startedAt`, then adds 7 days for SEV1 or 14 days for SEV2/SEV3, returning a `YYYY-MM-DD` string.
>
> #### 🖇️ Linked Issues
> Addresses [WOP-2127](ticket:jira/WOP-2127).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9b5654.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incident postmortem action items now display calculated due dates instead of "TBD" placeholders, varying by incident severity and resolution status.

* **Tests**
  * Added test coverage for action item due date calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->