### PR TITLE
test: add vi.useRealTimers() cleanup to timer-dependent tests (WOP-2134)

### DIFF
--- a/src/observability/pagerduty.test.ts
+++ b/src/observability/pagerduty.test.ts
@@ -7,6 +7,7 @@ describe("PagerDutyNotifier", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Summary
Closes WOP-2134

- Add `vi.useRealTimers()` to the `afterEach` block in `pagerduty.test.ts`
- Prevents fake timer leaks if a test assertion fails after `vi.useFakeTimers()` but before the inline `vi.useRealTimers()` call
- The other 4 observability test files already have proper cleanup; no changes needed there

## Test plan
- [x] `npx vitest run src/observability/pagerduty.test.ts` passes (8 tests)
- [x] `npm run check` passes (no lint or type errors introduced)

Generated with Claude Code

## Summary by Sourcery

Tests:
- Add vi.useRealTimers() to the afterEach hook in pagerduty.test.ts to guarantee timer cleanup even on failing tests.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `vi.useRealTimers()` cleanup to `PagerDutyNotifier` test suite
> Adds `vi.useRealTimers()` before `vi.restoreAllMocks()` in the `afterEach` hook of [pagerduty.test.ts](https://github.com/wopr-network/platform-core/pull/48/files#diff-52a50c72054391130be00f98fa829a163efd856c6cdbcc3f4d0fb4e4cc34e648) to ensure fake timers are torn down between tests. Without this, fake timers could leak across tests and cause intermittent failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f24d869.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->