### PR TITLE
feat(evm): add USDT and DAI on Base (stablecoin Phase 2)

### DIFF
--- a/src/billing/crypto/evm/__tests__/config.test.ts
+++ b/src/billing/crypto/evm/__tests__/config.test.ts
@@ -23,6 +23,18 @@ describe("getTokenConfig", () => {
     expect(cfg.contractAddress).toBe("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
   });
 
+  it("returns USDT on Base", () => {
+    const cfg = getTokenConfig("USDT", "base");
+    expect(cfg.decimals).toBe(6);
+    expect(cfg.contractAddress).toBe("0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2");
+  });
+
+  it("returns DAI on Base", () => {
+    const cfg = getTokenConfig("DAI", "base");
+    expect(cfg.decimals).toBe(18);
+    expect(cfg.contractAddress).toBe("0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb");
+  });
+
   it("throws on unsupported token/chain combo", () => {
     // biome-ignore lint/suspicious/noExplicitAny: testing invalid input
     expect(() => getTokenConfig("USDC" as any, "ethereum" as any)).toThrow("Unsupported token");

--- a/src/billing/crypto/evm/config.ts
+++ b/src/billing/crypto/evm/config.ts
@@ -10,12 +10,24 @@ const CHAINS: Record<EvmChain, ChainConfig> = {
   },
 };
 
-const TOKENS: Record<`${StablecoinToken}:${EvmChain}`, TokenConfig> = {
+const TOKENS: Partial<Record<`${StablecoinToken}:${EvmChain}`, TokenConfig>> = {
   "USDC:base": {
     token: "USDC",
     chain: "base",
     contractAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     decimals: 6,
+  },
+  "USDT:base": {
+    token: "USDT",
+    chain: "base",
+    contractAddress: "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2",
+    decimals: 6,
+  },
+  "DAI:base": {
+    token: "DAI",
+    chain: "base",
+    contractAddress: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",
+    decimals: 18,
   },
 };
 

--- a/src/billing/crypto/evm/types.ts
+++ b/src/billing/crypto/evm/types.ts
@@ -2,7 +2,7 @@
 export type EvmChain = "base";
 
 /** Supported stablecoin tokens. */
-export type StablecoinToken = "USDC";
+export type StablecoinToken = "USDC" | "USDT" | "DAI";
 
 /** Chain configuration. */
 export interface ChainConfig {


### PR DESCRIPTION
## Summary

- Expand `StablecoinToken` type to `"USDC" | "USDT" | "DAI"`
- Add USDT on Base (`0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2`, 6 decimals)
- Add DAI on Base (`0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb`, 18 decimals)
- 2 new config tests

Same node, same watcher, same settler, same ledger. Just more contract addresses.

## Test plan
- [ ] 37 EVM tests pass (including 2 new token config tests)
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add EVM-based stablecoin payment support on Base by extending crypto charges with on-chain metadata and introducing an EVM watcher, checkout, and settlement pipeline for stablecoin transfers.

New Features:
- Introduce an EVM stablecoin module with checkout, watcher, and settlement flows for stablecoin payments on Base.
- Support USDC, USDT, and DAI token configurations on the Base chain for on-chain payment processing.

Enhancements:
- Extend crypto charge records and repository APIs to store chain, token, deposit address, and derivation index metadata for on-chain payments.
- Export the new EVM stablecoin functionality through the existing crypto billing module barrel for reuse across the codebase.

Build:
- Add viem and @scure bip32/base libraries to support EVM interaction and HD wallet address derivation.

Documentation:
- Add a detailed implementation plan documenting the stablecoin Phase 1 architecture, file map, and rollout steps.

Tests:
- Add unit tests for EVM address derivation, chain/token config, watcher behavior, settlement logic, and stablecoin checkout flows, plus new repository tests for stablecoin charges.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add USDT and DAI token configs on Base for stablecoin billing
> Adds `USDT` (6 decimals, `0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2`) and `DAI` (18 decimals, `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb`) as supported tokens on the Base network in [config.ts](https://github.com/wopr-network/platform-core/pull/55/files#diff-4fd0bdcb75b31a7ad9a243cbe20fe40034bcb4e9f3a71b8d4ede43fb06df614f). The `StablecoinToken` type in [types.ts](https://github.com/wopr-network/platform-core/pull/55/files#diff-a77f7b4a90016ecdd10935130c6db3d4748a9e0278c8918c57f2d8a0f981fcb0) is expanded from `'USDC'` to include `'USDT'` and `'DAI'`. The `TOKENS` map type is relaxed to `Partial<Record>` to accommodate tokens not available on all networks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6a653e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->