### PR TITLE
feat: Chainlink price oracle for ETH and BTC

### DIFF
--- a/src/billing/crypto/index.ts
+++ b/src/billing/crypto/index.ts
@@ -4,6 +4,7 @@ export { createCryptoCheckout, MIN_PAYMENT_USD } from "./checkout.js";
 export type { CryptoConfig } from "./client.js";
 export { BTCPayClient, loadCryptoConfig } from "./client.js";
 export * from "./evm/index.js";
+export * from "./oracle/index.js";
 export type {
   CryptoBillingConfig,
   CryptoCheckoutOpts,

--- a/src/billing/crypto/oracle/__tests__/chainlink.test.ts
+++ b/src/billing/crypto/oracle/__tests__/chainlink.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { ChainlinkOracle } from "../chainlink.js";
+
+/**
+ * Encode a mock latestRoundData() response.
+ * Chainlink returns 5 × 32-byte ABI-encoded words:
+ *   roundId, answer, startedAt, updatedAt, answeredInRound
+ */
+function encodeRoundData(answer: bigint, updatedAtSec: number): string {
+  const pad = (v: bigint) => v.toString(16).padStart(64, "0");
+  return (
+    "0x" +
+    pad(1n) + // roundId
+    pad(answer) + // answer (price × 10^8)
+    pad(BigInt(updatedAtSec)) + // startedAt
+    pad(BigInt(updatedAtSec)) + // updatedAt
+    pad(1n) // answeredInRound
+  );
+}
+
+describe("ChainlinkOracle", () => {
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  it("decodes ETH/USD price from latestRoundData", async () => {
+    // ETH at $3,500.00 → answer = 3500 × 10^8 = 350_000_000_000
+    const rpc = vi.fn().mockResolvedValue(encodeRoundData(350_000_000_000n, nowSec));
+    const oracle = new ChainlinkOracle({ rpcCall: rpc });
+
+    const result = await oracle.getPrice("ETH");
+
+    expect(result.priceCents).toBe(350_000); // $3,500.00
+    expect(result.updatedAt).toBeInstanceOf(Date);
+    expect(rpc).toHaveBeenCalledWith("eth_call", [
+      { to: "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70", data: "0xfeaf968c" },
+      "latest",
+    ]);
+  });
+
+  it("decodes BTC/USD price from latestRoundData", async () => {
+    // BTC at $65,000.00 → answer = 65000 × 10^8 = 6_500_000_000_000
+    const rpc = vi.fn().mockResolvedValue(encodeRoundData(6_500_000_000_000n, nowSec));
+    const oracle = new ChainlinkOracle({ rpcCall: rpc });
+
+    const result = await oracle.getPrice("BTC");
+
+    expect(result.priceCents).toBe(6_500_000); // $65,000.00
+  });
+
+  it("handles fractional dollar prices correctly", async () => {
+    // ETH at $3,456.78 → answer = 345_678_000_000
+    const rpc = vi.fn().mockResolvedValue(encodeRoundData(345_678_000_000n, nowSec));
+    const oracle = new ChainlinkOracle({ rpcCall: rpc });
+
+    const result = await oracle.getPrice("ETH");
+
+    expect(result.priceCents).toBe(345_678); // $3,456.78
+  });
+
+  it("rejects stale prices", async () => {
+    const staleTime = nowSec - 7200; // 2 hours ago
+    const rpc = vi.fn().mockResolvedValue(encodeRoundData(350_000_000_000n, staleTime));
+    const oracle = new ChainlinkOracle({ rpcCall: rpc, maxStalenessMs: 3600_000 });
+
+    await expect(oracle.getPrice("ETH")).rejects.toThrow("stale");
+  });
+
+  it("rejects zero price", async () => {
+    const rpc = vi.fn().mockResolvedValue(encodeRoundData(0n, nowSec));
+    const oracle = new ChainlinkOracle({ rpcCall: rpc });
+
+    await expect(oracle.getPrice("ETH")).rejects.toThrow("Invalid price");
+  });
+
+  it("rejects malformed response", async () => {
+    const rpc = vi.fn().mockResolvedValue("0xdead");
+    const oracle = new ChainlinkOracle({ rpcCall: rpc });
+
+    await expect(oracle.getPrice("ETH")).rejects.toThrow("Malformed");
+  });
+
+  it("accepts custom feed addresses", async () => {
+    const customFeed = "0x1234567890abcdef1234567890abcdef12345678" as `0x${string}`;
+    const rpc = vi.fn().mockResolvedValue(encodeRoundData(350_000_000_000n, nowSec));
+    const oracle = new ChainlinkOracle({
+      rpcCall: rpc,
+      feedAddresses: { ETH: customFeed },
+    });
+
+    await oracle.getPrice("ETH");
+
+    expect(rpc).toHaveBeenCalledWith("eth_call", [{ to: customFeed, data: "0xfeaf968c" }, "latest"]);
+  });
+
+  it("respects custom staleness threshold", async () => {
+    const thirtyMinAgo = nowSec - 1800;
+    const rpc = vi.fn().mockResolvedValue(encodeRoundData(350_000_000_000n, thirtyMinAgo));
+
+    // 20-minute threshold → stale
+    const strict = new ChainlinkOracle({ rpcCall: rpc, maxStalenessMs: 20 * 60 * 1000 });
+    await expect(strict.getPrice("ETH")).rejects.toThrow("stale");
+
+    // 60-minute threshold → fresh
+    const relaxed = new ChainlinkOracle({ rpcCall: rpc, maxStalenessMs: 60 * 60 * 1000 });
+    const result = await relaxed.getPrice("ETH");
+    expect(result.priceCents).toBe(350_000);
+  });
+});

--- a/src/billing/crypto/oracle/__tests__/convert.test.ts
+++ b/src/billing/crypto/oracle/__tests__/convert.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { centsToNative, nativeToCents } from "../convert.js";
+
+describe("centsToNative", () => {
+  it("converts $50 to ETH wei at $3,500", () => {
+    // 5000 cents × 10^18 / 350000 cents = 14285714285714285n wei
+    const wei = centsToNative(5000, 350_000, 18);
+    expect(wei).toBe(14_285_714_285_714_285n);
+  });
+
+  it("converts $50 to BTC sats at $65,000", () => {
+    // 5000 cents × 10^8 / 6500000 cents = 76923n sats
+    const sats = centsToNative(5000, 6_500_000, 8);
+    expect(sats).toBe(76_923n);
+  });
+
+  it("converts $100 to ETH wei at $2,000", () => {
+    // 10000 cents × 10^18 / 200000 cents = 50000000000000000n wei (0.05 ETH)
+    const wei = centsToNative(10_000, 200_000, 18);
+    expect(wei).toBe(50_000_000_000_000_000n);
+  });
+
+  it("rejects non-integer amountCents", () => {
+    expect(() => centsToNative(50.5, 350_000, 18)).toThrow("positive integer");
+  });
+
+  it("rejects zero amountCents", () => {
+    expect(() => centsToNative(0, 350_000, 18)).toThrow("positive integer");
+  });
+
+  it("rejects zero priceCents", () => {
+    expect(() => centsToNative(5000, 0, 18)).toThrow("positive integer");
+  });
+
+  it("rejects negative decimals", () => {
+    expect(() => centsToNative(5000, 350_000, -1)).toThrow("non-negative integer");
+  });
+});
+
+describe("nativeToCents", () => {
+  it("converts ETH wei back to cents at $3,500", () => {
+    // 14285714285714285n wei × 350000 / 10^18 = 4999 cents (truncated)
+    const cents = nativeToCents(14_285_714_285_714_285n, 350_000, 18);
+    expect(cents).toBe(4999); // truncation from integer division
+  });
+
+  it("converts BTC sats back to cents at $65,000", () => {
+    // 76923n sats × 6500000 / 10^8 = 4999 cents (truncated)
+    const cents = nativeToCents(76_923n, 6_500_000, 8);
+    expect(cents).toBe(4999);
+  });
+
+  it("exact round-trip for clean division", () => {
+    // 0.05 ETH at $2,000 = $100
+    const cents = nativeToCents(50_000_000_000_000_000n, 200_000, 18);
+    expect(cents).toBe(10_000); // $100.00
+  });
+
+  it("rejects negative rawAmount", () => {
+    expect(() => nativeToCents(-1n, 350_000, 18)).toThrow("non-negative");
+  });
+});

--- a/src/billing/crypto/oracle/__tests__/fixed.test.ts
+++ b/src/billing/crypto/oracle/__tests__/fixed.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { FixedPriceOracle } from "../fixed.js";
+
+describe("FixedPriceOracle", () => {
+  it("returns default ETH price", async () => {
+    const oracle = new FixedPriceOracle();
+    const result = await oracle.getPrice("ETH");
+    expect(result.priceCents).toBe(350_000); // $3,500
+    expect(result.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it("returns default BTC price", async () => {
+    const oracle = new FixedPriceOracle();
+    const result = await oracle.getPrice("BTC");
+    expect(result.priceCents).toBe(6_500_000); // $65,000
+  });
+
+  it("accepts custom prices", async () => {
+    const oracle = new FixedPriceOracle({ ETH: 200_000, BTC: 5_000_000 });
+    expect((await oracle.getPrice("ETH")).priceCents).toBe(200_000);
+    expect((await oracle.getPrice("BTC")).priceCents).toBe(5_000_000);
+  });
+});

--- a/src/billing/crypto/oracle/chainlink.ts
+++ b/src/billing/crypto/oracle/chainlink.ts
@@ -1,0 +1,85 @@
+import type { IPriceOracle, PriceAsset, PriceResult } from "./types.js";
+
+/**
+ * Chainlink price feed addresses on Base mainnet.
+ * These are ERC-1967 proxy contracts — addresses are stable.
+ */
+const FEED_ADDRESSES: Record<PriceAsset, `0x${string}`> = {
+  ETH: "0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70",
+  BTC: "0x64c911996D3c6aC71f9b455B1E8E7266BcbD848F",
+};
+
+/** Function selector for latestRoundData(). */
+const LATEST_ROUND_DATA = "0xfeaf968c";
+
+/** Default max staleness: 1 hour. */
+const DEFAULT_MAX_STALENESS_MS = 60 * 60 * 1000;
+
+type RpcCall = (method: string, params: unknown[]) => Promise<unknown>;
+
+export interface ChainlinkOracleOpts {
+  rpcCall: RpcCall;
+  /** Override feed addresses (e.g. for testnet or Anvil forks). */
+  feedAddresses?: Partial<Record<PriceAsset, `0x${string}`>>;
+  /** Maximum age of price data before rejecting (ms). Default: 1 hour. */
+  maxStalenessMs?: number;
+}
+
+/**
+ * On-chain Chainlink price oracle.
+ *
+ * Reads latestRoundData() from Chainlink aggregator contracts via eth_call.
+ * No API key, no rate limits — just an RPC call to our own node.
+ *
+ * Chainlink USD feeds use 8 decimals. We convert to integer USD cents:
+ *   priceCents = answer / 10^6  (i.e. answer / 10^8 * 100)
+ */
+export class ChainlinkOracle implements IPriceOracle {
+  private readonly rpc: RpcCall;
+  private readonly feeds: Record<PriceAsset, `0x${string}`>;
+  private readonly maxStalenessMs: number;
+
+  constructor(opts: ChainlinkOracleOpts) {
+    this.rpc = opts.rpcCall;
+    this.feeds = { ...FEED_ADDRESSES, ...opts.feedAddresses };
+    this.maxStalenessMs = opts.maxStalenessMs ?? DEFAULT_MAX_STALENESS_MS;
+  }
+
+  async getPrice(asset: PriceAsset): Promise<PriceResult> {
+    const feedAddress = this.feeds[asset];
+    if (!feedAddress) throw new Error(`No price feed for asset: ${asset}`);
+
+    const result = (await this.rpc("eth_call", [{ to: feedAddress, data: LATEST_ROUND_DATA }, "latest"])) as string;
+
+    // ABI decode latestRoundData() return:
+    //   [0]  roundId       (uint80)  — skip
+    //   [1]  answer        (int256)  — price × 10^8
+    //   [2]  startedAt     (uint256) — skip
+    //   [3]  updatedAt     (uint256) — unix seconds
+    //   [4]  answeredInRound (uint80) — skip
+    const hex = result.slice(2);
+    if (hex.length < 320) {
+      throw new Error(`Malformed Chainlink response for ${asset}: expected 320 hex chars, got ${hex.length}`);
+    }
+
+    const answer = BigInt(`0x${hex.slice(64, 128)}`);
+    const updatedAtSec = Number(BigInt(`0x${hex.slice(192, 256)}`));
+    const updatedAt = new Date(updatedAtSec * 1000);
+
+    // Staleness guard.
+    const ageMs = Date.now() - updatedAt.getTime();
+    if (ageMs > this.maxStalenessMs) {
+      throw new Error(
+        `Price feed for ${asset} is stale (${Math.round(ageMs / 1000)}s old, max ${Math.round(this.maxStalenessMs / 1000)}s)`,
+      );
+    }
+
+    // Chainlink USD feeds: 8 decimals. answer / 10^6 = cents (integer).
+    const priceCents = Number(answer / 1_000_000n);
+    if (priceCents <= 0) {
+      throw new Error(`Invalid price for ${asset}: ${priceCents} cents`);
+    }
+
+    return { priceCents, updatedAt };
+  }
+}

--- a/src/billing/crypto/oracle/convert.ts
+++ b/src/billing/crypto/oracle/convert.ts
@@ -1,0 +1,38 @@
+/**
+ * Convert USD cents to native token amount using a price in cents.
+ *
+ * Formula: rawAmount = amountCents × 10^decimals / priceCents
+ *
+ * Examples:
+ *   $50 in ETH at $3,500:  centsToNative(5000, 350000, 18) = 14285714285714285n (≈0.01429 ETH)
+ *   $50 in BTC at $65,000: centsToNative(5000, 6500000, 8)  = 76923n (76,923 sats ≈ 0.00077 BTC)
+ *
+ * Integer math only. No floating point.
+ */
+export function centsToNative(amountCents: number, priceCents: number, decimals: number): bigint {
+  if (!Number.isInteger(amountCents) || amountCents <= 0) {
+    throw new Error(`amountCents must be a positive integer, got ${amountCents}`);
+  }
+  if (!Number.isInteger(priceCents) || priceCents <= 0) {
+    throw new Error(`priceCents must be a positive integer, got ${priceCents}`);
+  }
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    throw new Error(`decimals must be a non-negative integer, got ${decimals}`);
+  }
+  return (BigInt(amountCents) * 10n ** BigInt(decimals)) / BigInt(priceCents);
+}
+
+/**
+ * Convert native token amount back to USD cents using a price in cents.
+ *
+ * Inverse of centsToNative. Truncates fractional cents.
+ *
+ * Integer math only.
+ */
+export function nativeToCents(rawAmount: bigint, priceCents: number, decimals: number): number {
+  if (rawAmount < 0n) throw new Error("rawAmount must be non-negative");
+  if (!Number.isInteger(priceCents) || priceCents <= 0) {
+    throw new Error(`priceCents must be a positive integer, got ${priceCents}`);
+  }
+  return Number((rawAmount * BigInt(priceCents)) / 10n ** BigInt(decimals));
+}

--- a/src/billing/crypto/oracle/fixed.ts
+++ b/src/billing/crypto/oracle/fixed.ts
@@ -1,0 +1,23 @@
+import type { IPriceOracle, PriceAsset, PriceResult } from "./types.js";
+
+/**
+ * Fixed-price oracle for testing and local dev (Anvil, regtest).
+ * Returns hardcoded prices — no RPC calls.
+ */
+export class FixedPriceOracle implements IPriceOracle {
+  private readonly prices: Record<string, number>;
+
+  constructor(prices: Partial<Record<PriceAsset, number>> = {}) {
+    this.prices = {
+      ETH: 350_000, // $3,500
+      BTC: 6_500_000, // $65,000
+      ...prices,
+    };
+  }
+
+  async getPrice(asset: PriceAsset): Promise<PriceResult> {
+    const priceCents = this.prices[asset];
+    if (priceCents === undefined) throw new Error(`No fixed price for ${asset}`);
+    return { priceCents, updatedAt: new Date() };
+  }
+}

--- a/src/billing/crypto/oracle/index.ts
+++ b/src/billing/crypto/oracle/index.ts
@@ -1,0 +1,5 @@
+export type { ChainlinkOracleOpts } from "./chainlink.js";
+export { ChainlinkOracle } from "./chainlink.js";
+export { centsToNative, nativeToCents } from "./convert.js";
+export { FixedPriceOracle } from "./fixed.js";
+export type { IPriceOracle, PriceAsset, PriceResult } from "./types.js";

--- a/src/billing/crypto/oracle/types.ts
+++ b/src/billing/crypto/oracle/types.ts
@@ -1,0 +1,15 @@
+/** Assets with Chainlink price feeds. */
+export type PriceAsset = "ETH" | "BTC";
+
+/** Result from a price oracle query. */
+export interface PriceResult {
+  /** USD cents per 1 unit of asset (integer). */
+  priceCents: number;
+  /** When the price was last updated on-chain. */
+  updatedAt: Date;
+}
+
+/** Read-only price oracle. */
+export interface IPriceOracle {
+  getPrice(asset: PriceAsset): Promise<PriceResult>;
+}


### PR DESCRIPTION
## Summary
- Adds on-chain Chainlink price oracle reading ETH/USD and BTC/USD feeds on Base via `latestRoundData()`
- `ChainlinkOracle`: ABI decodes price data, staleness guard (1hr default), integer USD cents output
- `FixedPriceOracle`: hardcoded prices for testing and local dev (Anvil/regtest)
- `centsToNative` / `nativeToCents`: BigInt conversion between USD cents and native token amounts (ETH wei, BTC sats) — zero floating point
- 22 tests covering ABI decoding, staleness rejection, price conversion, edge cases

No API keys, no rate limits — just an `eth_call` to our own Base node. Enables ETH and BTC payment acceptance with live USD pricing.

## Test plan
- [x] Chainlink ABI decoding (ETH/USD, BTC/USD, fractional prices)
- [x] Staleness guard (reject >1hr, custom thresholds)
- [x] Zero/negative price rejection
- [x] Malformed response handling
- [x] Custom feed address override
- [x] centsToNative conversion (ETH wei, BTC sats)
- [x] nativeToCents inverse conversion
- [x] Edge cases (non-integer, zero, negative inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a USD-centric crypto price oracle layer for billing, backed by Chainlink on Base with a fixed-price fallback and conversion helpers.

New Features:
- Add a Chainlink-based on-chain price oracle for ETH and BTC priced in integer USD cents.
- Provide a fixed-price oracle implementation for testing and local development without RPC dependencies.
- Expose utility functions to convert between USD cents and native token units using integer math only.

Tests:
- Add unit tests for Chainlink oracle decoding, staleness handling, error cases, and custom configuration.
- Add unit tests for cents/native conversion logic and the fixed-price oracle behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Chainlink price oracle for ETH and BTC with USD cent conversion utilities
> - Adds [`ChainlinkOracle`](https://github.com/wopr-network/platform-core/pull/59/files#diff-cafe2007a5bb22f59d0b5effd614b45437def89c08c94c24f82f3c580f54842f) that calls `latestRoundData()` on Chainlink feeds (Base mainnet) via an injected `rpcCall`, decodes the 8-decimal USD answer to integer cents, and rejects stale, zero, or malformed responses.
> - Adds [`FixedPriceOracle`](https://github.com/wopr-network/platform-core/pull/59/files#diff-9011222bd200a8c9e2f8416145f2620758306aef13d76f4741770d3bf9086e68) for test/dev use, returning hardcoded cent prices with optional per-asset overrides.
> - Adds [`centsToNative` and `nativeToCents`](https://github.com/wopr-network/platform-core/pull/59/files#diff-6196e3c972e9d5003aa7155bff6267ac75eaa7214f3c229ce1e6e7ebdb922b69) helpers for integer-math conversion between USD cents and on-chain token units (bigint), with input validation on both.
> - Exports all oracle types and implementations from `src/billing/crypto` via a new barrel export.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a8d329.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->