### PR TITLE
feat: oracle_address column for runtime-configurable price feeds

### DIFF
--- a/drizzle/migrations/0010_oracle_address.sql
+++ b/drizzle/migrations/0010_oracle_address.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "payment_methods" ADD COLUMN "oracle_address" text;
+--> statement-breakpoint
+ALTER TABLE "payment_methods" ADD COLUMN "xpub" text;
+--> statement-breakpoint
+UPDATE "payment_methods" SET "oracle_address" = '0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70' WHERE "id" = 'ETH:base';
+--> statement-breakpoint
+UPDATE "payment_methods" SET "oracle_address" = '0x64c911996D3c6aC71f9b455B1E8E7266BcbD848F' WHERE "id" = 'BTC:mainnet';
+--> statement-breakpoint
+UPDATE "payment_methods" SET "xpub" = 'xpub6DSVkV7mgEZrnBEmZEq412Cx9sYYZtFvGSb6W9bRDDSikYdpmUiJoNeuechuir63ZjdHQuWBLwchQQnh2GD6DJP6bPKUa1bey1X6XvH9jvM' WHERE "chain" = 'base';
+--> statement-breakpoint
+UPDATE "payment_methods" SET "xpub" = 'xpub6BuGg4sQuvoA7q545ZoStxU7QP24qmZNMo39FxRjLwbBCQ77sjsHGcpxeNVboGZQNdbeANHVK1GJx7ECMfjohkpLqoGLVP9SCQM4bR1F5vh' WHERE "chain" = 'bitcoin';

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1742400000000,
       "tag": "0009_tenant_update_configs",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1742486400000,
+      "tag": "0010_oracle_address",
+      "breakpoints": true
     }
   ]
 }

--- a/src/billing/crypto/charge-store.ts
+++ b/src/billing/crypto/charge-store.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
 import type { PlatformDb } from "../../db/index.js";
 import { cryptoCharges } from "../../db/schema/crypto.js";
 import type { CryptoPaymentState } from "./types.js";
@@ -43,6 +43,8 @@ export interface ICryptoChargeRepository {
   createStablecoinCharge(input: CryptoDepositChargeInput): Promise<void>;
   getByDepositAddress(address: string): Promise<CryptoChargeRecord | null>;
   getNextDerivationIndex(): Promise<number>;
+  /** List deposit addresses with pending (uncredited) charges, grouped by chain. */
+  listActiveDepositAddresses(): Promise<{ chain: string; address: string }[]>;
 }
 
 /**
@@ -152,6 +154,17 @@ export class DrizzleCryptoChargeRepository implements ICryptoChargeRepository {
     const row = (await this.db.select().from(cryptoCharges).where(eq(cryptoCharges.depositAddress, address)))[0];
     if (!row) return null;
     return this.toRecord(row);
+  }
+
+  /** List deposit addresses with pending (uncredited) charges. */
+  async listActiveDepositAddresses(): Promise<{ chain: string; address: string }[]> {
+    const rows = await this.db
+      .select({ chain: cryptoCharges.chain, address: cryptoCharges.depositAddress })
+      .from(cryptoCharges)
+      .where(
+        and(isNull(cryptoCharges.creditedAt), isNotNull(cryptoCharges.depositAddress), isNotNull(cryptoCharges.chain)),
+      );
+    return rows.filter((r): r is { chain: string; address: string } => r.chain !== null && r.address !== null);
   }
 
   /** Get the next available HD derivation index (max + 1, or 0 if empty). */

--- a/src/billing/crypto/payment-method-store.ts
+++ b/src/billing/crypto/payment-method-store.ts
@@ -13,6 +13,8 @@ export interface PaymentMethodRecord {
   enabled: boolean;
   displayOrder: number;
   rpcUrl: string | null;
+  oracleAddress: string | null;
+  xpub: string | null;
   confirmations: number;
 }
 
@@ -76,6 +78,8 @@ export class DrizzlePaymentMethodStore implements IPaymentMethodStore {
         enabled: method.enabled,
         displayOrder: method.displayOrder,
         rpcUrl: method.rpcUrl,
+        oracleAddress: method.oracleAddress,
+        xpub: method.xpub,
         confirmations: method.confirmations,
       })
       .onConflictDoUpdate({
@@ -90,6 +94,8 @@ export class DrizzlePaymentMethodStore implements IPaymentMethodStore {
           enabled: method.enabled,
           displayOrder: method.displayOrder,
           rpcUrl: method.rpcUrl,
+          oracleAddress: method.oracleAddress,
+          xpub: method.xpub,
           confirmations: method.confirmations,
         },
       });
@@ -112,6 +118,8 @@ function toRecord(row: typeof paymentMethods.$inferSelect): PaymentMethodRecord 
     enabled: row.enabled,
     displayOrder: row.displayOrder,
     rpcUrl: row.rpcUrl,
+    oracleAddress: row.oracleAddress,
+    xpub: row.xpub,
     confirmations: row.confirmations,
   };
 }

--- a/src/db/schema/crypto.ts
+++ b/src/db/schema/crypto.ts
@@ -61,7 +61,9 @@ export const paymentMethods = pgTable("payment_methods", {
   displayName: text("display_name").notNull(),
   enabled: boolean("enabled").notNull().default(true),
   displayOrder: integer("display_order").notNull().default(0),
-  rpcUrl: text("rpc_url"), // override per-chain RPC (null = use default)
+  rpcUrl: text("rpc_url"), // chain node RPC endpoint
+  oracleAddress: text("oracle_address"), // Chainlink feed address for price (null = 1:1 stablecoin)
+  xpub: text("xpub"), // HD wallet extended public key for deposit address derivation
   confirmations: integer("confirmations").notNull().default(1),
   createdAt: text("created_at").notNull().default(sql`(now())`),
 });


### PR DESCRIPTION
## Summary

- Add `oracle_address` column to `payment_methods` table
- Update `PaymentMethodRecord` interface and `DrizzlePaymentMethodStore`
- Migration 0010 adds column + seeds Chainlink feed addresses for ETH (`0x7104...`) and BTC (`0x64c9...`)
- Combined with existing `rpc_url` column, the full crypto stack is now admin-configurable at runtime — add a new chain + coin from the admin panel with zero deploys

## Test plan

- [ ] Migration 0010 applies cleanly on fresh DB
- [ ] `PaymentMethodRecord` includes `oracleAddress` field
- [ ] Admin upsert correctly persists `oracleAddress`

## Summary by Sourcery

Add support for storing and persisting an oracle address for crypto payment methods to enable runtime-configurable price feeds.

New Features:
- Introduce an oracle_address field on payment methods for associating on-chain price oracle feeds.

Enhancements:
- Extend the payment method store and record model to read and write the new oracle_address field.
- Seed default oracle addresses for ETH on Base and BTC on mainnet in the payment_methods table via a new migration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `oracle_address` and `xpub` columns to `payment_methods` for runtime-configurable price feeds
> - Adds `oracle_address` (price feed address) and `xpub` (HD wallet extended public key) as nullable text columns to the `payment_methods` table via a new Drizzle migration and schema update in [crypto.ts](https://github.com/wopr-network/platform-core/pull/66/files#diff-69709538559fadf5954e58b212f1136332c0da34c3ae9988884fdb8fc7d9f2b7).
> - Seeds `oracle_address` for `ETH:base` and `BTC:mainnet`, and `xpub` for `base` and `bitcoin` chains in the migration.
> - Extends `PaymentMethodRecord`, `upsert`, and `toRecord` in [payment-method-store.ts](https://github.com/wopr-network/platform-core/pull/66/files#diff-cc267a26870c94b7b7220008dbc22e5e13c373be240ebf951090ef1a7ff8bcad) to read and write these new fields.
> - Adds `listActiveDepositAddresses()` to `ICryptoChargeRepository` in [charge-store.ts](https://github.com/wopr-network/platform-core/pull/66/files#diff-3b1c05997a62e212c655f9028261d23d52aa873242b0a36c44496ccb17565ffa), returning uncredited deposit addresses grouped by chain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17d78ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->