### PR TITLE
refactor: lazy getter for fleet update config router

### DIFF
--- a/src/trpc/fleet-update-config-router.ts
+++ b/src/trpc/fleet-update-config-router.ts
@@ -3,10 +3,10 @@ import { logger } from "../config/logger.js";
 import type { ITenantUpdateConfigRepository } from "../fleet/tenant-update-config-repository.js";
 import { protectedProcedure, router } from "./init.js";
 
-export function createFleetUpdateConfigRouter(configRepo: ITenantUpdateConfigRepository) {
+export function createFleetUpdateConfigRouter(getConfigRepo: () => ITenantUpdateConfigRepository) {
   return router({
     getUpdateConfig: protectedProcedure.input(z.object({ tenantId: z.string().min(1) })).query(async ({ input }) => {
-      return configRepo.get(input.tenantId);
+      return getConfigRepo().get(input.tenantId);
     }),
 
     setUpdateConfig: protectedProcedure
@@ -18,7 +18,7 @@ export function createFleetUpdateConfigRouter(configRepo: ITenantUpdateConfigRep
         }),
       )
       .mutation(async ({ input }) => {
-        await configRepo.upsert(input.tenantId, {
+        await getConfigRepo().upsert(input.tenantId, {
           mode: input.mode,
           preferredHourUtc: input.preferredHourUtc ?? 3,
         });


### PR DESCRIPTION
## Summary
- Changes `createFleetUpdateConfigRouter` parameter from `ITenantUpdateConfigRepository` to `() => ITenantUpdateConfigRepository`
- Repo is resolved at request time, not module-load time — prevents eager `getDb()` calls before DB pool is initialized
- Addresses Greptile review finding on paperclip-platform PR #12

## Test plan
- [ ] Existing fleet update config tests pass
- [ ] Router procedures still correctly read/write tenant update config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce per-tenant fleet update configuration backed by a new database table and repository, integrate it into the fleet updater and TRPC API, and emit update-related fleet events.

New Features:
- Add per-tenant update configuration model, repository interface, and Drizzle-backed implementation.
- Expose a TRPC router for reading and updating tenant fleet update configurations.
- Export tenant update config and fleet update config router modules from fleet and TRPC entrypoints.

Enhancements:
- Update fleet updater to respect per-tenant manual update settings in addition to profile-level policies.
- Extend fleet event emitter to support bot.updated and bot.update_failed events and wire them into the updater callbacks.
- Add lazy initialization for the tenant update config repository in fleet services and reset it in test helpers.

Tests:
- Add test scaffolding for the tenant update config repository.

Chores:
- Add Drizzle schema and SQL migration for the tenant_update_configs table.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change `createFleetUpdateConfigRouter` to accept a repository supplier function
> Updates [fleet-update-config-router.ts](https://github.com/wopr-network/platform-core/pull/67/files#diff-93caba81c60cd6b86de12c6df428851ef0242809fc254d627ffd4d60929aea14) so the router factory takes a `() => ITenantUpdateConfigRepository` supplier instead of a direct repository instance. Both `getUpdateConfig` and `setUpdateConfig` now call the supplier at request time rather than using a captured instance at construction time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e589bcc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->