### PR TITLE
fix: lowercase deposit addresses + monotonic migration timestamps

### DIFF
--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -5,14 +5,14 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1773159905670,
+      "when": 1741622400000,
       "tag": "0000_slippery_mandrill",
       "breakpoints": true
     },
     {
       "idx": 1,
       "version": "7",
-      "when": 1773279600000,
+      "when": 1741708800000,
       "tag": "0001_infrastructure_extraction",
       "breakpoints": true
     },

--- a/src/billing/crypto/charge-store.ts
+++ b/src/billing/crypto/charge-store.ts
@@ -144,14 +144,16 @@ export class DrizzleCryptoChargeRepository implements ICryptoChargeRepository {
       status: "New",
       chain: input.chain,
       token: input.token,
-      depositAddress: input.depositAddress,
+      depositAddress: input.depositAddress.toLowerCase(),
       derivationIndex: input.derivationIndex,
     });
   }
 
   /** Look up a charge by its deposit address. */
   async getByDepositAddress(address: string): Promise<CryptoChargeRecord | null> {
-    const row = (await this.db.select().from(cryptoCharges).where(eq(cryptoCharges.depositAddress, address)))[0];
+    const row = (
+      await this.db.select().from(cryptoCharges).where(eq(cryptoCharges.depositAddress, address.toLowerCase()))
+    )[0];
     if (!row) return null;
     return this.toRecord(row);
   }


### PR DESCRIPTION
## Summary

Two bugs found during E2E crypto payment testing:

1. **Deposit address case mismatch** — `deriveDepositAddress()` returns checksummed EVM addresses (`0x23Edd02d...`) but the settler looks up by lowercased address from log topics (`0x23edd02d...`). Postgres `=` is case-sensitive → settler returns "Invalid" for valid payments.
   - Fix: `createStablecoinCharge` now lowercases `depositAddress` before INSERT

2. **Migration timestamp ordering** — Migrations 0000/0001 had timestamps in 2026 (~1773xxx) while 0002+ had timestamps in 2025 (~1741xxx). Drizzle uses `max(created_at)` to determine what's applied, so it thinks 0002-0011 are already applied when 0000/0001 exist.
   - Fix: Set 0000/0001 timestamps to precede 0002 (monotonically increasing)

## Test plan

- [x] E2E verified: checkout → USDC transfer → watcher detects → settler credits $10 → charge marked Settled
- [ ] Fresh DB migration applies all 12 migrations in order

## Summary by Sourcery

Ensure crypto billing uses lowercase deposit addresses and maintain monotonic migration timestamps in the Drizzle migration journal.

Bug Fixes:
- Normalize stored crypto deposit addresses to lowercase to match settler lookups and prevent valid payments from being marked invalid.

Chores:
- Adjust migration journal timestamps so Drizzle applies migrations in correct chronological order.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lowercase deposit addresses on write and lookup in `DrizzleCryptoChargeRepository`
> - `createStablecoinCharge` now calls `toLowerCase()` on the deposit address before persisting, ensuring addresses are stored in a consistent format.
> - `getByDepositAddress` lowercases the input before querying, so lookups match regardless of the case provided by the caller.
> - Migration timestamps in [_journal.json](https://github.com/wopr-network/platform-core/pull/71/files#diff-2ebfc74764d6d3c51dcf5c4fc13e6548d530aa1d5baf43b0f4983ace93477813) are updated to be monotonically increasing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4046d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->