### PR TITLE
feat: onManualTenantsSkipped callback for update-available notifications

### DIFF
--- a/src/fleet/init-fleet-updater.ts
+++ b/src/fleet/init-fleet-updater.ts
@@ -39,6 +39,8 @@ export interface FleetUpdaterConfig {
   configRepo?: ITenantUpdateConfigRepository;
   /** Optional fleet event emitter. When provided, bot.updated / bot.update_failed events are emitted. */
   eventEmitter?: FleetEventEmitter;
+  /** Called with manual-mode tenant IDs when a new image is available but they are excluded from rollout. */
+  onManualTenantsSkipped?: (tenantIds: string[]) => void;
 }
 
 export interface FleetUpdaterHandle {
@@ -79,6 +81,7 @@ export function initFleetUpdater(
     onRolloutComplete,
     configRepo,
     eventEmitter: configEventEmitter,
+    onManualTenantsSkipped,
   } = config;
 
   const emitter = configEventEmitter ?? new FleetEventEmitter();
@@ -94,19 +97,43 @@ export function initFleetUpdater(
     strategy,
     getUpdatableProfiles: async () => {
       const profiles = await profileRepo.list();
-      const nonManualPolicy = profiles.filter((p) => p.updatePolicy !== "manual");
 
-      if (!configRepo) return nonManualPolicy;
+      // Separate profiles by updatePolicy
+      const manualPolicyIds: string[] = [];
+      const nonManualPolicy = profiles.filter((p) => {
+        if (p.updatePolicy === "manual") {
+          manualPolicyIds.push(p.tenantId);
+          return false;
+        }
+        return true;
+      });
+
+      if (!configRepo) {
+        if (manualPolicyIds.length > 0 && onManualTenantsSkipped) {
+          onManualTenantsSkipped([...new Set(manualPolicyIds)]);
+        }
+        return nonManualPolicy;
+      }
 
       // Filter out tenants whose per-tenant config is set to manual
+      const configManualIds: string[] = [];
       const results = await Promise.all(
         nonManualPolicy.map(async (p) => {
           const tenantCfg = await configRepo.get(p.tenantId);
           // If tenant has an explicit config with mode=manual, exclude
-          if (tenantCfg && tenantCfg.mode === "manual") return null;
+          if (tenantCfg && tenantCfg.mode === "manual") {
+            configManualIds.push(p.tenantId);
+            return null;
+          }
           return p;
         }),
       );
+
+      const allManualIds = [...manualPolicyIds, ...configManualIds];
+      if (allManualIds.length > 0 && onManualTenantsSkipped) {
+        onManualTenantsSkipped([...new Set(allManualIds)]);
+      }
+
       return results.filter((p) => p !== null);
     },
     onBotUpdated: (result) => {


### PR DESCRIPTION
## Summary
- Adds `onManualTenantsSkipped` callback to `FleetUpdaterConfig`
- When ImagePoller triggers a rollout, manual-mode tenants are identified and the callback fires with their IDs
- Enables consumers to send "update available" emails to manual tenants

## Test plan
- [ ] Manual-mode tenants trigger callback with correct IDs
- [ ] Auto-mode tenants still get rolled out normally
- [ ] Callback receives deduplicated tenant IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Introduce an optional onManualTenantsSkipped callback on FleetUpdaterConfig to receive IDs of manual-mode tenants excluded from rollouts.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `onManualTenantsSkipped` callback to `initFleetUpdater` for update-available notifications
> Adds an optional `onManualTenantsSkipped` callback to `FleetUpdaterConfig` in [init-fleet-updater.ts](https://github.com/wopr-network/platform-core/pull/75/files#diff-2303afbdc6fd92a29f2c2ebbb5ead572c873cd37ec3d9727fe0100007118275e). When a new image is available but some tenants are excluded from rollout due to a `manual` update policy (either at the profile level or per-tenant config level), the callback is invoked with a deduplicated list of the skipped tenant IDs. The filtered profile list returned to the caller is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f7dd07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a callback mechanism to report tenants that are skipped during fleet updates when manual update policies are configured, providing enhanced visibility into update operations and their outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->