### PR TITLE
test: fleet notification, handlebars renderer, admin fleet routes

### DIFF
--- a/src/email/handlebars-renderer.test.ts
+++ b/src/email/handlebars-renderer.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import { HandlebarsRenderer } from "./handlebars-renderer.js";
+import type { INotificationTemplateRepository, NotificationTemplateRow } from "./notification-repository-types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTemplate(overrides: Partial<NotificationTemplateRow> = {}): NotificationTemplateRow {
+  return {
+    id: "tpl-1",
+    name: "test-template",
+    description: "A test template",
+    subject: "Hello {{name}}",
+    htmlBody: "<h1>Hello {{name}}</h1>",
+    textBody: "Hello {{name}}",
+    active: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeRepo(templates: Record<string, NotificationTemplateRow | null> = {}): INotificationTemplateRepository {
+  return {
+    getByName: vi.fn().mockImplementation((name: string) => Promise.resolve(templates[name] ?? null)),
+    list: vi.fn().mockResolvedValue(Object.values(templates).filter(Boolean)),
+    upsert: vi.fn().mockResolvedValue(undefined),
+  } as unknown as INotificationTemplateRepository;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HandlebarsRenderer", () => {
+  it("returns null for unknown template", async () => {
+    const repo = makeRepo({});
+    const renderer = new HandlebarsRenderer(repo);
+
+    const result = await renderer.render("nonexistent", { name: "World" });
+
+    expect(result).toBeNull();
+    expect(repo.getByName).toHaveBeenCalledWith("nonexistent");
+  });
+
+  it("returns null for inactive template", async () => {
+    const repo = makeRepo({
+      "inactive-tpl": makeTemplate({ name: "inactive-tpl", active: false }),
+    });
+    const renderer = new HandlebarsRenderer(repo);
+
+    const result = await renderer.render("inactive-tpl", { name: "World" });
+
+    expect(result).toBeNull();
+  });
+
+  it("compiles Handlebars and returns subject/html/text", async () => {
+    const repo = makeRepo({
+      greeting: makeTemplate({
+        name: "greeting",
+        subject: "Hi {{name}}!",
+        htmlBody: "<p>Welcome, {{name}}!</p>",
+        textBody: "Welcome, {{name}}!",
+      }),
+    });
+    const renderer = new HandlebarsRenderer(repo);
+
+    const result = await renderer.render("greeting", { name: "Alice" });
+
+    expect(result).not.toBeNull();
+    expect(result?.subject).toBe("Hi Alice!");
+    expect(result?.html).toBe("<p>Welcome, Alice!</p>");
+    expect(result?.text).toBe("Welcome, Alice!");
+  });
+
+  it("injects currentYear automatically", async () => {
+    const repo = makeRepo({
+      footer: makeTemplate({
+        name: "footer",
+        subject: "Year: {{currentYear}}",
+        htmlBody: "<p>&copy; {{currentYear}}</p>",
+        textBody: "(c) {{currentYear}}",
+      }),
+    });
+    const renderer = new HandlebarsRenderer(repo);
+
+    const result = await renderer.render("footer", {});
+
+    const year = new Date().getFullYear();
+    expect(result?.subject).toBe(`Year: ${year}`);
+    expect(result?.html).toBe(`<p>&copy; ${year}</p>`);
+    expect(result?.text).toBe(`(c) ${year}`);
+  });
+
+  it("does not override explicit currentYear from data", async () => {
+    const repo = makeRepo({
+      footer: makeTemplate({
+        name: "footer",
+        subject: "Year: {{currentYear}}",
+        htmlBody: "<p>{{currentYear}}</p>",
+        textBody: "{{currentYear}}",
+      }),
+    });
+    const renderer = new HandlebarsRenderer(repo);
+
+    const result = await renderer.render("footer", { currentYear: 2099 });
+
+    expect(result?.subject).toBe("Year: 2099");
+  });
+
+  describe("helpers", () => {
+    it("eq helper returns true for equal values", async () => {
+      const repo = makeRepo({
+        cond: makeTemplate({
+          name: "cond",
+          subject: '{{#if (eq status "active")}}Active{{else}}Inactive{{/if}}',
+          htmlBody: "ok",
+          textBody: "ok",
+        }),
+      });
+      const renderer = new HandlebarsRenderer(repo);
+
+      const active = await renderer.render("cond", { status: "active" });
+      expect(active?.subject).toBe("Active");
+
+      const inactive = await renderer.render("cond", { status: "disabled" });
+      expect(inactive?.subject).toBe("Inactive");
+    });
+
+    it("gt helper compares numbers", async () => {
+      const repo = makeRepo({
+        gt: makeTemplate({
+          name: "gt",
+          subject: "{{#if (gt count 5)}}Many{{else}}Few{{/if}}",
+          htmlBody: "ok",
+          textBody: "ok",
+        }),
+      });
+      const renderer = new HandlebarsRenderer(repo);
+
+      const many = await renderer.render("gt", { count: 10 });
+      expect(many?.subject).toBe("Many");
+
+      const few = await renderer.render("gt", { count: 3 });
+      expect(few?.subject).toBe("Few");
+    });
+
+    it("formatDate helper formats timestamps", async () => {
+      const repo = makeRepo({
+        dated: makeTemplate({
+          name: "dated",
+          subject: "Date: {{formatDate ts}}",
+          htmlBody: "ok",
+          textBody: "ok",
+        }),
+      });
+      const renderer = new HandlebarsRenderer(repo);
+
+      // Use noon UTC to avoid timezone date-boundary shifts
+      const ts = new Date("2025-01-15T12:00:00Z").getTime();
+      const result = await renderer.render("dated", { ts });
+
+      // The formatted string uses en-US locale with year/month/day
+      const expected = new Date(ts).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+      expect(result?.subject).toBe(`Date: ${expected}`);
+    });
+
+    it("formatDate helper passes through non-numeric values", async () => {
+      const repo = makeRepo({
+        dated: makeTemplate({
+          name: "dated",
+          subject: "Date: {{formatDate ts}}",
+          htmlBody: "ok",
+          textBody: "ok",
+        }),
+      });
+      const renderer = new HandlebarsRenderer(repo);
+
+      const result = await renderer.render("dated", { ts: "not-a-number" });
+
+      expect(result?.subject).toBe("Date: not-a-number");
+    });
+
+    it("escapeHtml helper escapes special characters", async () => {
+      const repo = makeRepo({
+        esc: makeTemplate({
+          name: "esc",
+          subject: "Safe: {{escapeHtml input}}",
+          htmlBody: "ok",
+          textBody: "ok",
+        }),
+      });
+      const renderer = new HandlebarsRenderer(repo);
+
+      const result = await renderer.render("esc", {
+        input: '<script>alert("xss")</script>',
+      });
+
+      expect(result?.subject).toContain("&lt;script&gt;");
+      expect(result?.subject).toContain("&quot;xss&quot;");
+      expect(result?.subject).not.toContain("<script>");
+    });
+  });
+});

--- a/src/fleet/fleet-notification-listener.test.ts
+++ b/src/fleet/fleet-notification-listener.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { INotificationPreferencesRepository, NotificationPrefs } from "../email/notification-repository-types.js";
+import type { NotificationService } from "../email/notification-service.js";
+import type { BotFleetEvent } from "./fleet-event-emitter.js";
+import { FleetEventEmitter } from "./fleet-event-emitter.js";
+import { initFleetNotificationListener } from "./fleet-notification-listener.js";
+
+vi.mock("../config/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEBOUNCE_MS = 100;
+
+function makePrefs(overrides: Partial<NotificationPrefs> = {}): NotificationPrefs {
+  return {
+    billing_low_balance: true,
+    billing_receipts: true,
+    billing_auto_topup: true,
+    agent_channel_disconnect: true,
+    agent_status_changes: false,
+    account_role_changes: true,
+    account_team_invites: true,
+    fleet_updates: true,
+    ...overrides,
+  };
+}
+
+function makePrefsRepo(prefs: NotificationPrefs = makePrefs()): INotificationPreferencesRepository {
+  return {
+    get: vi.fn().mockResolvedValue(prefs),
+    update: vi.fn().mockResolvedValue(undefined),
+  } as unknown as INotificationPreferencesRepository;
+}
+
+function makeNotificationService(): NotificationService {
+  return {
+    notifyFleetUpdateComplete: vi.fn(),
+    notifyFleetUpdateAvailable: vi.fn(),
+    notifyLowBalance: vi.fn(),
+  } as unknown as NotificationService;
+}
+
+function botUpdated(tenantId: string, version = "v1.2.0"): BotFleetEvent {
+  return {
+    type: "bot.updated",
+    botId: `bot-${Math.random().toString(36).slice(2, 6)}`,
+    tenantId,
+    timestamp: new Date().toISOString(),
+    version,
+  };
+}
+
+function botUpdateFailed(tenantId: string, version = "v1.2.0"): BotFleetEvent {
+  return {
+    type: "bot.update_failed",
+    botId: `bot-${Math.random().toString(36).slice(2, 6)}`,
+    tenantId,
+    timestamp: new Date().toISOString(),
+    version,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("initFleetNotificationListener", () => {
+  let emitter: FleetEventEmitter;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    emitter = new FleetEventEmitter();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ignores non-bot events (node events)", async () => {
+    const notificationService = makeNotificationService();
+    const preferences = makePrefsRepo();
+
+    initFleetNotificationListener({
+      eventEmitter: emitter,
+      notificationService,
+      preferences,
+      resolveEmail: vi.fn().mockResolvedValue("user@example.com"),
+      debounceMs: DEBOUNCE_MS,
+    });
+
+    emitter.emit({
+      type: "node.provisioned",
+      nodeId: "node-1",
+      timestamp: new Date().toISOString(),
+    });
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 50);
+
+    expect(notificationService.notifyFleetUpdateComplete).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-update bot events (bot.started, bot.stopped)", async () => {
+    const notificationService = makeNotificationService();
+    const preferences = makePrefsRepo();
+
+    initFleetNotificationListener({
+      eventEmitter: emitter,
+      notificationService,
+      preferences,
+      resolveEmail: vi.fn().mockResolvedValue("user@example.com"),
+      debounceMs: DEBOUNCE_MS,
+    });
+
+    emitter.emit({
+      type: "bot.started",
+      botId: "bot-1",
+      tenantId: "t1",
+      timestamp: new Date().toISOString(),
+    });
+
+    emitter.emit({
+      type: "bot.stopped",
+      botId: "bot-2",
+      tenantId: "t1",
+      timestamp: new Date().toISOString(),
+    });
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 50);
+
+    expect(notificationService.notifyFleetUpdateComplete).not.toHaveBeenCalled();
+  });
+
+  it("aggregates multiple bot.updated events per tenant into one notification", async () => {
+    const notificationService = makeNotificationService();
+    const preferences = makePrefsRepo();
+    const resolveEmail = vi.fn().mockResolvedValue("owner@example.com");
+
+    initFleetNotificationListener({
+      eventEmitter: emitter,
+      notificationService,
+      preferences,
+      resolveEmail,
+      debounceMs: DEBOUNCE_MS,
+    });
+
+    // Emit 3 successful updates for the same tenant
+    emitter.emit(botUpdated("t1", "v2.0.0"));
+    emitter.emit(botUpdated("t1", "v2.0.0"));
+    emitter.emit(botUpdated("t1", "v2.0.0"));
+
+    // No notification yet — debounce hasn't fired
+    expect(notificationService.notifyFleetUpdateComplete).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 50);
+
+    expect(notificationService.notifyFleetUpdateComplete).toHaveBeenCalledOnce();
+    expect(notificationService.notifyFleetUpdateComplete).toHaveBeenCalledWith(
+      "t1",
+      "owner@example.com",
+      "v2.0.0",
+      3, // succeeded
+      0, // failed
+    );
+  });
+
+  it("sends summary with correct succeeded/failed counts after debounce", async () => {
+    const notificationService = makeNotificationService();
+    const preferences = makePrefsRepo();
+    const resolveEmail = vi.fn().mockResolvedValue("owner@example.com");
+
+    initFleetNotificationListener({
+      eventEmitter: emitter,
+      notificationService,
+      preferences,
+      resolveEmail,
+      debounceMs: DEBOUNCE_MS,
+    });
+
+    emitter.emit(botUpdated("t1", "v3.0.0"));
+    emitter.emit(botUpdated("t1", "v3.0.0"));
+    emitter.emit(botUpdateFailed("t1", "v3.0.0"));
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 50);
+
+    expect(notificationService.notifyFleetUpdateComplete).toHaveBeenCalledWith(
+      "t1",
+      "owner@example.com",
+      "v3.0.0",
+      2, // succeeded
+      1, // failed
+    );
+  });
+
+  it("updates version from subsequent events", async () => {
+    const notificationService = makeNotificationService();
+    const preferences = makePrefsRepo();
+    const resolveEmail = vi.fn().mockResolvedValue("owner@example.com");
+
+    initFleetNotificationListener({
+      eventEmitter: emitter,
+      notificationService,
+      preferences,
+      resolveEmail,
+      debounceMs: DEBOUNCE_MS,
+    });
+
+    // First event has v1.0.0, subsequent event changes to v1.1.0
+    emitter.emit(botUpdated("t1", "v1.0.0"));
+    emitter.emit(botUpdated("t1", "v1.1.0"));
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 50);
+
+    expect(notificationService.notifyFleetUpdateComplete).toHaveBeenCalledWith(
+      "t1",
+      "owner@example.com",
+      "v1.1.0", // updated to latest version
+      2,
+      0,
+    );
+  });
+
+  it("checks fleet_updates preference — skips if disabled", async () => {
+    const notificationService = makeNotificationService();
+    const preferences = makePrefsRepo(makePrefs({ fleet_updates: false }));
+    const resolveEmail = vi.fn().mockResolvedValue("owner@example.com");
+
+    initFleetNotificationListener({
+      eventEmitter: emitter,
+      notificationService,
+      preferences,
+      resolveEmail,
+      debounceMs: DEBOUNCE_MS,
+    });
+
+    emitter.emit(botUpdated("t1"));
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 50);
+
+    expect(preferences.get).toHaveBeenCalledWith("t1");
+    expect(notificationService.notifyFleetUpdateComplete).not.toHaveBeenCalled();
+  });
+
+  it("skips if email resolver returns null", async () => {
+    const notificationService = makeNotificationService();
+    const preferences = makePrefsRepo();
+    const resolveEmail = vi.fn().mockResolvedValue(null);
+
+    initFleetNotificationListener({
+      eventEmitter: emitter,
+      notificationService,
+      preferences,
+      resolveEmail,
+      debounceMs: DEBOUNCE_MS,
+    });
+
+    emitter.emit(botUpdated("t1"));
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 50);
+
+    expect(resolveEmail).toHaveBeenCalledWith("t1");
+    expect(notificationService.notifyFleetUpdateComplete).not.toHaveBeenCalled();
+  });
+
+  it("async shutdown flushes pending notifications", async () => {
+    const notificationService = makeNotificationService();
+    const preferences = makePrefsRepo();
+    const resolveEmail = vi.fn().mockResolvedValue("owner@example.com");
+
+    const shutdown = initFleetNotificationListener({
+      eventEmitter: emitter,
+      notificationService,
+      preferences,
+      resolveEmail,
+      debounceMs: DEBOUNCE_MS,
+    });
+
+    emitter.emit(botUpdated("t1", "v5.0.0"));
+    emitter.emit(botUpdated("t2", "v5.0.0"));
+
+    // Don't advance timers — flush via shutdown instead
+    await shutdown();
+
+    // Both tenants should have been flushed
+    expect(notificationService.notifyFleetUpdateComplete).toHaveBeenCalledTimes(2);
+
+    const calls = vi.mocked(notificationService.notifyFleetUpdateComplete).mock.calls;
+    const tenantIds = calls.map((c) => c[0]);
+    expect(tenantIds).toContain("t1");
+    expect(tenantIds).toContain("t2");
+  });
+
+  it("no further events after shutdown", async () => {
+    const notificationService = makeNotificationService();
+    const preferences = makePrefsRepo();
+    const resolveEmail = vi.fn().mockResolvedValue("owner@example.com");
+
+    const shutdown = initFleetNotificationListener({
+      eventEmitter: emitter,
+      notificationService,
+      preferences,
+      resolveEmail,
+      debounceMs: DEBOUNCE_MS,
+    });
+
+    await shutdown();
+
+    // Events after shutdown should not trigger anything
+    emitter.emit(botUpdated("t1"));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MS + 50);
+
+    expect(notificationService.notifyFleetUpdateComplete).not.toHaveBeenCalled();
+  });
+});

--- a/src/fleet/init-fleet-updater.test.ts
+++ b/src/fleet/init-fleet-updater.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests the profile-filtering + onManualTenantsSkipped logic used inside initFleetUpdater.
+ *
+ * We can't import initFleetUpdater directly because it constructs ImagePoller,
+ * ContainerUpdater, etc. which pull in heavy dependencies that cause hangs.
+ * Instead, we replicate the getUpdatableProfiles closure from initFleetUpdater
+ * and test it in isolation via a RolloutOrchestrator with mock deps.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { IBotProfileRepository } from "./bot-profile-repository.js";
+import { RolloutOrchestrator } from "./rollout-orchestrator.js";
+import type { IRolloutStrategy } from "./rollout-strategy.js";
+import type { ITenantUpdateConfigRepository } from "./tenant-update-config-repository.js";
+import type { BotProfile } from "./types.js";
+import type { ContainerUpdater } from "./updater.js";
+import type { VolumeSnapshotManager } from "./volume-snapshot-manager.js";
+
+vi.mock("../config/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProfileWithFields(fields: { id: string; tenantId: string; updatePolicy: "auto" | "manual" }): BotProfile {
+  return {
+    ...fields,
+    image: "ghcr.io/org/img:latest",
+  } as unknown as BotProfile;
+}
+
+function makeProfileRepo(profiles: BotProfile[]): IBotProfileRepository {
+  return {
+    list: vi.fn().mockResolvedValue(profiles),
+    get: vi
+      .fn()
+      .mockImplementation((id: string) =>
+        Promise.resolve(profiles.find((p) => (p as unknown as { id: string }).id === id) ?? null),
+      ),
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(false),
+  } as unknown as IBotProfileRepository;
+}
+
+function makeConfigRepo(
+  configs: Record<string, { mode: "auto" | "manual"; preferredHourUtc: number }> = {},
+): ITenantUpdateConfigRepository {
+  return {
+    get: vi.fn().mockImplementation((tenantId: string) => {
+      const cfg = configs[tenantId];
+      return Promise.resolve(cfg ? { tenantId, ...cfg, updatedAt: Date.now() } : null);
+    }),
+    upsert: vi.fn().mockResolvedValue(undefined),
+    listAutoEnabled: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function makeMockUpdater(): ContainerUpdater {
+  return {
+    updateBot: vi.fn().mockResolvedValue({
+      botId: "",
+      success: true,
+      previousImage: "",
+      newImage: "",
+      previousDigest: null,
+      newDigest: null,
+      rolledBack: false,
+    }),
+  } as unknown as ContainerUpdater;
+}
+
+function makeMockSnapshotManager(): VolumeSnapshotManager {
+  return {
+    snapshot: vi.fn(),
+    restore: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as VolumeSnapshotManager;
+}
+
+function makeMockStrategy(): IRolloutStrategy {
+  return {
+    nextBatch: vi.fn().mockImplementation((remaining: BotProfile[]) => remaining),
+    pauseDuration: vi.fn().mockReturnValue(0),
+    onBotFailure: vi.fn().mockReturnValue("skip" as const),
+    maxRetries: vi.fn().mockReturnValue(0),
+    healthCheckTimeout: vi.fn().mockReturnValue(0),
+  };
+}
+
+/**
+ * Builds the same getUpdatableProfiles closure that initFleetUpdater creates,
+ * so we can test the filtering + callback logic without importing the heavy module.
+ */
+function buildGetUpdatableProfiles(
+  profileRepo: IBotProfileRepository,
+  configRepo: ITenantUpdateConfigRepository | undefined,
+  onManualTenantsSkipped: ((tenantIds: string[]) => void) | undefined,
+): () => Promise<BotProfile[]> {
+  return async () => {
+    const profiles = await profileRepo.list();
+
+    const manualPolicyIds: string[] = [];
+    const nonManualPolicy = profiles.filter((p) => {
+      if (p.updatePolicy === "manual") {
+        manualPolicyIds.push(p.tenantId);
+        return false;
+      }
+      return true;
+    });
+
+    if (!configRepo) {
+      if (manualPolicyIds.length > 0 && onManualTenantsSkipped) {
+        onManualTenantsSkipped([...new Set(manualPolicyIds)]);
+      }
+      return nonManualPolicy;
+    }
+
+    const configManualIds: string[] = [];
+    const results = await Promise.all(
+      nonManualPolicy.map(async (p) => {
+        const tenantCfg = await configRepo.get(p.tenantId);
+        if (tenantCfg && tenantCfg.mode === "manual") {
+          configManualIds.push(p.tenantId);
+          return null;
+        }
+        return p;
+      }),
+    );
+
+    const allManualIds = [...manualPolicyIds, ...configManualIds];
+    if (allManualIds.length > 0 && onManualTenantsSkipped) {
+      onManualTenantsSkipped([...new Set(allManualIds)]);
+    }
+
+    return results.filter((p): p is BotProfile => p !== null);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("initFleetUpdater — onManualTenantsSkipped", () => {
+  it("callback fires with tenant IDs of manual-mode tenants (policy-based)", async () => {
+    const profiles = [
+      makeProfileWithFields({ id: "b1", tenantId: "t-manual", updatePolicy: "manual" }),
+      makeProfileWithFields({ id: "b2", tenantId: "t-auto", updatePolicy: "auto" }),
+    ];
+    const profileRepo = makeProfileRepo(profiles);
+    const onManualTenantsSkipped = vi.fn();
+
+    const orchestrator = new RolloutOrchestrator({
+      updater: makeMockUpdater(),
+      snapshotManager: makeMockSnapshotManager(),
+      strategy: makeMockStrategy(),
+      getUpdatableProfiles: buildGetUpdatableProfiles(profileRepo, undefined, onManualTenantsSkipped),
+    });
+
+    await orchestrator.rollout();
+
+    expect(onManualTenantsSkipped).toHaveBeenCalledWith(["t-manual"]);
+  });
+
+  it("callback deduplicates tenant IDs", async () => {
+    const profiles = [
+      makeProfileWithFields({ id: "b1", tenantId: "t-dup", updatePolicy: "manual" }),
+      makeProfileWithFields({ id: "b2", tenantId: "t-dup", updatePolicy: "manual" }),
+      makeProfileWithFields({ id: "b3", tenantId: "t-auto", updatePolicy: "auto" }),
+    ];
+    const profileRepo = makeProfileRepo(profiles);
+    const onManualTenantsSkipped = vi.fn();
+
+    const orchestrator = new RolloutOrchestrator({
+      updater: makeMockUpdater(),
+      snapshotManager: makeMockSnapshotManager(),
+      strategy: makeMockStrategy(),
+      getUpdatableProfiles: buildGetUpdatableProfiles(profileRepo, undefined, onManualTenantsSkipped),
+    });
+
+    await orchestrator.rollout();
+
+    expect(onManualTenantsSkipped).toHaveBeenCalledWith(["t-dup"]);
+  });
+
+  it("callback not called when no manual tenants exist", async () => {
+    const profiles = [
+      makeProfileWithFields({ id: "b1", tenantId: "t1", updatePolicy: "auto" }),
+      makeProfileWithFields({ id: "b2", tenantId: "t2", updatePolicy: "auto" }),
+    ];
+    const profileRepo = makeProfileRepo(profiles);
+    const onManualTenantsSkipped = vi.fn();
+
+    const orchestrator = new RolloutOrchestrator({
+      updater: makeMockUpdater(),
+      snapshotManager: makeMockSnapshotManager(),
+      strategy: makeMockStrategy(),
+      getUpdatableProfiles: buildGetUpdatableProfiles(profileRepo, undefined, onManualTenantsSkipped),
+    });
+
+    await orchestrator.rollout();
+
+    expect(onManualTenantsSkipped).not.toHaveBeenCalled();
+  });
+
+  it("callback fires with config-repo manual tenants when configRepo is provided", async () => {
+    const profiles = [
+      makeProfileWithFields({ id: "b1", tenantId: "t-cfg-manual", updatePolicy: "auto" }),
+      makeProfileWithFields({ id: "b2", tenantId: "t-cfg-auto", updatePolicy: "auto" }),
+    ];
+    const profileRepo = makeProfileRepo(profiles);
+    const configRepo = makeConfigRepo({
+      "t-cfg-manual": { mode: "manual", preferredHourUtc: 3 },
+    });
+    const onManualTenantsSkipped = vi.fn();
+
+    const orchestrator = new RolloutOrchestrator({
+      updater: makeMockUpdater(),
+      snapshotManager: makeMockSnapshotManager(),
+      strategy: makeMockStrategy(),
+      getUpdatableProfiles: buildGetUpdatableProfiles(profileRepo, configRepo, onManualTenantsSkipped),
+    });
+
+    await orchestrator.rollout();
+
+    expect(onManualTenantsSkipped).toHaveBeenCalledWith(["t-cfg-manual"]);
+  });
+});

--- a/src/trpc/admin-fleet-update-router.test.ts
+++ b/src/trpc/admin-fleet-update-router.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RolloutOrchestrator } from "../fleet/rollout-orchestrator.js";
+import type { ITenantUpdateConfigRepository, TenantUpdateConfig } from "../fleet/tenant-update-config-repository.js";
+import type { IOrgMemberRepository } from "../tenancy/org-member-repository.js";
+import { createAdminFleetUpdateRouter } from "./admin-fleet-update-router.js";
+import { createCallerFactory, router, setTrpcOrgMemberRepo } from "./init.js";
+
+vi.mock("../config/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockOrgRepo(): IOrgMemberRepository {
+  return {
+    listMembers: vi.fn().mockResolvedValue([]),
+    addMember: vi.fn().mockResolvedValue(undefined),
+    updateMemberRole: vi.fn().mockResolvedValue(undefined),
+    removeMember: vi.fn().mockResolvedValue(undefined),
+    findMember: vi.fn().mockResolvedValue(null),
+    countAdminsAndOwners: vi.fn().mockResolvedValue(0),
+    listInvites: vi.fn().mockResolvedValue([]),
+    createInvite: vi.fn().mockResolvedValue(undefined),
+    findInviteById: vi.fn().mockResolvedValue(null),
+    findInviteByToken: vi.fn().mockResolvedValue(null),
+    deleteInvite: vi.fn().mockResolvedValue(undefined),
+    deleteAllMembers: vi.fn().mockResolvedValue(undefined),
+    deleteAllInvites: vi.fn().mockResolvedValue(undefined),
+    listOrgsByUser: vi.fn().mockResolvedValue([]),
+    markInviteAccepted: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IOrgMemberRepository;
+}
+
+function makeOrchestrator(overrides: Partial<RolloutOrchestrator> = {}): RolloutOrchestrator {
+  return {
+    isRolling: false,
+    rollout: vi.fn().mockResolvedValue({
+      totalBots: 0,
+      succeeded: 0,
+      failed: 0,
+      skipped: 0,
+      aborted: false,
+      alreadyRunning: false,
+      results: [],
+    }),
+    ...overrides,
+  } as unknown as RolloutOrchestrator;
+}
+
+function makeConfigRepo(configs: Record<string, TenantUpdateConfig> = {}): ITenantUpdateConfigRepository {
+  return {
+    get: vi.fn().mockImplementation((tenantId: string) => Promise.resolve(configs[tenantId] ?? null)),
+    upsert: vi.fn().mockResolvedValue(undefined),
+    listAutoEnabled: vi.fn().mockResolvedValue(Object.values(configs)),
+  };
+}
+
+const adminCtx = {
+  user: { id: "admin-1", roles: ["platform_admin"] },
+  tenantId: undefined,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createAdminFleetUpdateRouter", () => {
+  let orchestrator: RolloutOrchestrator;
+  let configRepo: ITenantUpdateConfigRepository;
+
+  beforeEach(() => {
+    setTrpcOrgMemberRepo(makeMockOrgRepo());
+    orchestrator = makeOrchestrator();
+    configRepo = makeConfigRepo();
+  });
+
+  function makeCaller() {
+    const fleetRouter = createAdminFleetUpdateRouter(
+      () => orchestrator,
+      () => configRepo,
+    );
+    const appRouter = router({ fleet: fleetRouter });
+    const createCaller = createCallerFactory(appRouter);
+    return createCaller(adminCtx);
+  }
+
+  describe("rolloutStatus", () => {
+    it("returns isRolling from orchestrator (false)", async () => {
+      const caller = makeCaller();
+      const status = await caller.fleet.rolloutStatus();
+      expect(status).toEqual({ isRolling: false });
+    });
+
+    it("returns isRolling from orchestrator (true)", async () => {
+      orchestrator = makeOrchestrator({ isRolling: true } as Partial<RolloutOrchestrator>);
+      const caller = makeCaller();
+      const status = await caller.fleet.rolloutStatus();
+      expect(status).toEqual({ isRolling: true });
+    });
+  });
+
+  describe("forceRollout", () => {
+    it("calls orchestrator.rollout()", async () => {
+      const caller = makeCaller();
+      const result = await caller.fleet.forceRollout();
+
+      expect(result).toEqual({ triggered: true });
+      expect(orchestrator.rollout).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("listTenantConfigs", () => {
+    it("delegates to repo.listAutoEnabled()", async () => {
+      const configs: TenantUpdateConfig[] = [
+        { tenantId: "t1", mode: "auto", preferredHourUtc: 3, updatedAt: Date.now() },
+        { tenantId: "t2", mode: "auto", preferredHourUtc: 12, updatedAt: Date.now() },
+      ];
+      vi.mocked(configRepo.listAutoEnabled).mockResolvedValue(configs);
+
+      const caller = makeCaller();
+      const result = await caller.fleet.listTenantConfigs();
+
+      expect(configRepo.listAutoEnabled).toHaveBeenCalledOnce();
+      expect(result).toEqual(configs);
+    });
+  });
+
+  describe("setTenantConfig", () => {
+    it("preserves existing preferredHourUtc when not provided", async () => {
+      const existing: TenantUpdateConfig = {
+        tenantId: "t1",
+        mode: "auto",
+        preferredHourUtc: 17,
+        updatedAt: Date.now(),
+      };
+      vi.mocked(configRepo.get).mockResolvedValue(existing);
+
+      const caller = makeCaller();
+      await caller.fleet.setTenantConfig({ tenantId: "t1", mode: "manual" });
+
+      expect(configRepo.get).toHaveBeenCalledWith("t1");
+      expect(configRepo.upsert).toHaveBeenCalledWith("t1", {
+        mode: "manual",
+        preferredHourUtc: 17, // preserved from existing
+      });
+    });
+
+    it("uses provided preferredHourUtc when given", async () => {
+      const existing: TenantUpdateConfig = {
+        tenantId: "t1",
+        mode: "auto",
+        preferredHourUtc: 17,
+        updatedAt: Date.now(),
+      };
+      vi.mocked(configRepo.get).mockResolvedValue(existing);
+
+      const caller = makeCaller();
+      await caller.fleet.setTenantConfig({
+        tenantId: "t1",
+        mode: "auto",
+        preferredHourUtc: 9,
+      });
+
+      expect(configRepo.upsert).toHaveBeenCalledWith("t1", {
+        mode: "auto",
+        preferredHourUtc: 9,
+      });
+    });
+
+    it("defaults to 3 when no existing config and preferredHourUtc not provided", async () => {
+      vi.mocked(configRepo.get).mockResolvedValue(null);
+
+      const caller = makeCaller();
+      await caller.fleet.setTenantConfig({ tenantId: "t-new", mode: "auto" });
+
+      expect(configRepo.upsert).toHaveBeenCalledWith("t-new", {
+        mode: "auto",
+        preferredHourUtc: 3, // default
+      });
+    });
+  });
+
+  it("rejects non-admin users", async () => {
+    const fleetRouter = createAdminFleetUpdateRouter(
+      () => orchestrator,
+      () => configRepo,
+    );
+    const appRouter = router({ fleet: fleetRouter });
+    const createCaller = createCallerFactory(appRouter);
+    const caller = createCaller({ user: { id: "u1", roles: ["user"] }, tenantId: undefined });
+
+    await expect(caller.fleet.rolloutStatus()).rejects.toThrow("Platform admin role required");
+  });
+});


### PR DESCRIPTION
## Summary
31 new unit tests covering fleet auto-update email notification pipeline:

- **HandlebarsRenderer** (10 tests) — render/null/inactive, currentYear injection, eq/gt/formatDate/escapeHtml helpers
- **FleetNotificationListener** (9 tests) — debounce aggregation, succeeded/failed counts, version update, preference gating, null email skip, shutdown flush
- **initFleetUpdater onManualTenantsSkipped** (4 tests) — fires for manual tenants, deduplicates, configRepo integration
- **AdminFleetUpdateRouter** (8 tests) — rolloutStatus, forceRollout, listTenantConfigs, setTenantConfig preserves preferredHourUtc, rejects non-admin

## Test plan
- [ ] `npx vitest run src/email/handlebars-renderer.test.ts` — 10 pass
- [ ] `npx vitest run src/fleet/fleet-notification-listener.test.ts` — 9 pass
- [ ] `npx vitest run src/fleet/init-fleet-updater.test.ts` — 4 pass
- [ ] `npx vitest run src/trpc/admin-fleet-update-router.test.ts` — 8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add unit tests for fleet auto-update notifications, manual-tenant rollout handling, email template rendering, and admin fleet update TRPC router.

Tests:
- Add coverage for fleet notification listener debounce aggregation, preference gating, email resolution, and shutdown flushing.
- Add tests for initFleetUpdater profile filtering and onManualTenantsSkipped callback behavior with and without tenant config repository.
- Add tests for HandlebarsRenderer template lookup, activation state, currentYear injection, and custom helpers (eq, gt, formatDate, escapeHtml).
- Add tests for admin fleet update router rollout status, force rollout, tenant config listing/updating, and admin-only access control.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test coverage for fleet notification, handlebars renderer, and admin fleet routes
> - Adds a Vitest suite for [`HandlebarsRenderer`](https://github.com/wopr-network/platform-core/pull/76/files#diff-8070078fe636f0e3b9c91c8f81534f225dbbb1481354f8fc5d0bc0dd5024a780) covering unknown/inactive templates, subject/html/text compilation, `currentYear` auto-injection, and helpers (`eq`, `gt`, `formatDate`, `escapeHtml`).
> - Adds a suite for [`initFleetNotificationListener`](https://github.com/wopr-network/platform-core/pull/76/files#diff-db0fa6703d55d39c8e630a236f08659ffd2236d394c732dc08f9e61226d2af94) covering event filtering, debounced per-tenant aggregation, succeeded/failed counts, fleet update preferences, and async shutdown flush.
> - Adds a suite for [`initFleetUpdater`](https://github.com/wopr-network/platform-core/pull/76/files#diff-ba8b5cf3b2b219a6e1cdad686a055bff7d8494f7c47f3abe8e34bf140bd17fb3) validating `getUpdatableProfiles` closure logic, including policy-based manual tenant reporting, deduplication, and config-repo manual mode.
> - Adds a suite for [`createAdminFleetUpdateRouter`](https://github.com/wopr-network/platform-core/pull/76/files#diff-12101089f5d33a3e4c886763cb29f4c0099cc355828434d13b7e39d27eb32ee4) covering rollout status, force rollout, tenant config listing, `preferredHourUtc` defaulting, and non-admin rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca81747.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->