### PR TITLE
fix: pass image tag to onManualTenantsSkipped callback

### DIFF
--- a/src/fleet/init-fleet-updater.test.ts
+++ b/src/fleet/init-fleet-updater.test.ts
@@ -100,7 +100,8 @@ function makeMockStrategy(): IRolloutStrategy {
 function buildGetUpdatableProfiles(
   profileRepo: IBotProfileRepository,
   configRepo: ITenantUpdateConfigRepository | undefined,
-  onManualTenantsSkipped: ((tenantIds: string[]) => void) | undefined,
+  onManualTenantsSkipped: ((tenantIds: string[], imageTag: string) => void) | undefined,
+  imageTag = "v1.2.3",
 ): () => Promise<BotProfile[]> {
   return async () => {
     const profiles = await profileRepo.list();
@@ -116,7 +117,7 @@ function buildGetUpdatableProfiles(
 
     if (!configRepo) {
       if (manualPolicyIds.length > 0 && onManualTenantsSkipped) {
-        onManualTenantsSkipped([...new Set(manualPolicyIds)]);
+        onManualTenantsSkipped([...new Set(manualPolicyIds)], imageTag);
       }
       return nonManualPolicy;
     }
@@ -135,7 +136,7 @@ function buildGetUpdatableProfiles(
 
     const allManualIds = [...manualPolicyIds, ...configManualIds];
     if (allManualIds.length > 0 && onManualTenantsSkipped) {
-      onManualTenantsSkipped([...new Set(allManualIds)]);
+      onManualTenantsSkipped([...new Set(allManualIds)], imageTag);
     }
 
     return results.filter((p): p is BotProfile => p !== null);
@@ -164,7 +165,7 @@ describe("initFleetUpdater — onManualTenantsSkipped", () => {
 
     await orchestrator.rollout();
 
-    expect(onManualTenantsSkipped).toHaveBeenCalledWith(["t-manual"]);
+    expect(onManualTenantsSkipped).toHaveBeenCalledWith(["t-manual"], "v1.2.3");
   });
 
   it("callback deduplicates tenant IDs", async () => {
@@ -185,7 +186,7 @@ describe("initFleetUpdater — onManualTenantsSkipped", () => {
 
     await orchestrator.rollout();
 
-    expect(onManualTenantsSkipped).toHaveBeenCalledWith(["t-dup"]);
+    expect(onManualTenantsSkipped).toHaveBeenCalledWith(["t-dup"], "v1.2.3");
   });
 
   it("callback not called when no manual tenants exist", async () => {
@@ -228,6 +229,6 @@ describe("initFleetUpdater — onManualTenantsSkipped", () => {
 
     await orchestrator.rollout();
 
-    expect(onManualTenantsSkipped).toHaveBeenCalledWith(["t-cfg-manual"]);
+    expect(onManualTenantsSkipped).toHaveBeenCalledWith(["t-cfg-manual"], "v1.2.3");
   });
 });

--- a/src/fleet/init-fleet-updater.ts
+++ b/src/fleet/init-fleet-updater.ts
@@ -40,7 +40,7 @@ export interface FleetUpdaterConfig {
   /** Optional fleet event emitter. When provided, bot.updated / bot.update_failed events are emitted. */
   eventEmitter?: FleetEventEmitter;
   /** Called with manual-mode tenant IDs when a new image is available but they are excluded from rollout. */
-  onManualTenantsSkipped?: (tenantIds: string[]) => void;
+  onManualTenantsSkipped?: (tenantIds: string[], imageTag: string) => void;
 }
 
 export interface FleetUpdaterHandle {
@@ -91,6 +91,11 @@ export function initFleetUpdater(
   const snapshotManager = new VolumeSnapshotManager(docker, snapshotDir);
   const strategy = createRolloutStrategy(strategyType, strategyOptions);
 
+  // Captured by the onUpdateAvailable handler and read by getUpdatableProfiles.
+  // Set before each orchestrator.rollout() call so the callback receives the
+  // image tag that triggered this rollout rather than a stale "latest" placeholder.
+  let currentImageTag = "latest";
+
   const orchestrator = new RolloutOrchestrator({
     updater,
     snapshotManager,
@@ -110,7 +115,7 @@ export function initFleetUpdater(
 
       if (!configRepo) {
         if (manualPolicyIds.length > 0 && onManualTenantsSkipped) {
-          onManualTenantsSkipped([...new Set(manualPolicyIds)]);
+          onManualTenantsSkipped([...new Set(manualPolicyIds)], currentImageTag);
         }
         return nonManualPolicy;
       }
@@ -131,7 +136,7 @@ export function initFleetUpdater(
 
       const allManualIds = [...manualPolicyIds, ...configManualIds];
       if (allManualIds.length > 0 && onManualTenantsSkipped) {
-        onManualTenantsSkipped([...new Set(allManualIds)]);
+        onManualTenantsSkipped([...new Set(allManualIds)], currentImageTag);
       }
 
       return results.filter((p) => p !== null);
@@ -169,11 +174,24 @@ export function initFleetUpdater(
   // Wire the detection → orchestration pipeline.
   // Any digest change triggers a fleet-wide rollout because the managed image
   // is shared across all tenants — one new digest means all bots need updating.
-  poller.onUpdateAvailable = async (_botId: string, _newDigest: string) => {
+  poller.onUpdateAvailable = async (botId: string, _newDigest: string) => {
     if (orchestrator.isRolling) {
       logger.debug("Skipping update trigger — rollout already in progress");
       return;
     }
+
+    // Resolve the image tag from the bot that triggered the update so that
+    // onManualTenantsSkipped receives the real version instead of "latest".
+    try {
+      const triggeringProfile = await profileStore.get(botId);
+      if (triggeringProfile) {
+        const img = triggeringProfile.image;
+        currentImageTag = img.includes(":") ? (img.split(":").pop() ?? "latest") : "latest";
+      }
+    } catch {
+      // Best-effort — currentImageTag stays at previous value
+    }
+
     logger.info("New image digest detected — starting fleet-wide rollout");
     await orchestrator.rollout().catch((err) => {
       logger.error("Rollout failed", { err });


### PR DESCRIPTION
## Summary
- Changed `onManualTenantsSkipped` callback signature from `(tenantIds: string[]) => void` to `(tenantIds: string[], imageTag: string) => void`
- The `onUpdateAvailable` handler now resolves the triggering bot's profile to extract the real image tag (e.g. `v1.2.3`) before starting a rollout
- The captured image tag is threaded through the `getUpdatableProfiles` closure to the callback, replacing the hardcoded `"latest"` placeholder

## Follow-up
After this merges and publishes, `paperclip-platform` needs a `@wopr-network/platform-core` bump + update to `onManualTenantsSkipped: (tenantIds, imageTag) =>` to use the real tag in `notifyFleetUpdateAvailable`.

## Test plan
- [x] Updated `init-fleet-updater.test.ts` assertions to verify `imageTag` is passed
- [x] `npx biome check` clean
- [x] `npx tsc --noEmit` — no new errors (2 pre-existing in `btc/address-gen.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Propagate the actual image tag that triggered a rollout into the manual-tenant skip callback so consumers can act on the real version instead of a placeholder.

Enhancements:
- Extend the fleet updater configuration so onManualTenantsSkipped receives both tenant IDs and the resolved image tag for the rollout.
- Resolve the triggering bot's image tag when an update is detected and thread it through rollout processing for use by callbacks.

Tests:
- Update fleet updater tests to assert that onManualTenantsSkipped is invoked with the expected tenant IDs and image tag.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass image tag to `onManualTenantsSkipped` callback in `initFleetUpdater`
> - The `onManualTenantsSkipped` callback in [`init-fleet-updater.ts`](https://github.com/wopr-network/platform-core/pull/77/files#diff-2303afbdc6fd92a29f2c2ebbb5ead572c873cd37ec3d9727fe0100007118275e) previously only received the skipped tenant IDs; it now also receives the `imageTag` that triggered the rollout.
> - A `currentImageTag` variable (initialized to `"latest"`) is captured in the `getUpdatableProfiles` closure and updated in the `onUpdateAvailable` handler by fetching the triggering bot's profile and extracting the tag after the last `:`.
> - If the profile fetch fails, `currentImageTag` retains its previous value via try/catch.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 97cbb87. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->