### PR TITLE
fix: ETH referenceId mismatch + underpayment tolerance

### DIFF
--- a/src/billing/crypto/btc/settler.ts
+++ b/src/billing/crypto/btc/settler.ts
@@ -44,8 +44,9 @@ export async function settleBtcPayment(deps: BtcSettlerDeps, event: BtcPaymentEv
     return { handled: true, status: "Settled", tenant: charge.tenantId, creditedCents: 0 };
   }
 
-  // Underpayment check
-  if (event.amountUsdCents < charge.amountUsdCents) {
+  // 2% underpayment tolerance for oracle price drift between checkout and settlement.
+  const UNDERPAYMENT_TOLERANCE = 0.98;
+  if (event.amountUsdCents < charge.amountUsdCents * UNDERPAYMENT_TOLERANCE) {
     return { handled: true, status: "Settled", tenant: charge.tenantId, creditedCents: 0 };
   }
 

--- a/src/billing/crypto/evm/eth-settler.ts
+++ b/src/billing/crypto/evm/eth-settler.ts
@@ -42,7 +42,9 @@ export async function settleEthPayment(deps: EthSettlerDeps, event: EthPaymentEv
     return { handled: true, status: "Settled", tenant: charge.tenantId, creditedCents: 0 };
   }
 
-  if (event.amountUsdCents < charge.amountUsdCents) {
+  // 2% underpayment tolerance for oracle price drift between checkout and settlement.
+  const UNDERPAYMENT_TOLERANCE = 0.98;
+  if (event.amountUsdCents < charge.amountUsdCents * UNDERPAYMENT_TOLERANCE) {
     return { handled: true, status: "Settled", tenant: charge.tenantId, creditedCents: 0 };
   }
 

--- a/src/billing/crypto/unified-checkout.ts
+++ b/src/billing/crypto/unified-checkout.ts
@@ -101,7 +101,7 @@ async function handleNativeEvm(
     amountUsd,
     token: "ETH",
     chain: method.chain,
-    referenceId: `eth:${method.chain}:${depositAddress}`,
+    referenceId: `${method.type}:${method.chain}:${depositAddress}`,
     priceCents,
   };
 }


### PR DESCRIPTION
## Summary
- **ETH referenceId mismatch**: `handleNativeEth` returned `eth:chain:addr` but `deriveAndStore` stored `native:chain:addr` in DB. Client couldn't poll charge status because the referenceId didn't match. Fixed to use `${method.type}:chain:addr` consistently.
- **2% underpayment tolerance**: Native asset settlers (ETH, BTC) now accept payments within 2% of the charge amount. Oracle price drift between checkout and settlement caused valid $10 ETH payments to be rejected as underpayment ($9.997 vs $10.00).

## Found during E2E testing
Full crypto E2E test script: `paperclip-platform/scripts/e2e-crypto-test.sh`

## Test plan
- [ ] USDC E2E: checkout → transfer → watcher detect → settler credit
- [ ] ETH E2E: checkout → transfer → watcher detect → settler credit (was failing)
- [ ] BTC settler tolerance (unit test — regtest address format prevents full E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align native ETH reference IDs with stored charge records and introduce a small underpayment tolerance for BTC and ETH settlements to account for price drift.

Bug Fixes:
- Fix ETH native checkout referenceId format so clients can correctly poll charge status.
- Allow BTC settlements that are within a 2% underpayment threshold to be treated as settled.
- Allow ETH settlements that are within a 2% underpayment threshold to be treated as settled.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ETH referenceId mismatch and add 2% underpayment tolerance to BTC and ETH settlers
> - Fixes the `referenceId` in [`unified-checkout.ts`](https://github.com/wopr-network/platform-core/pull/78/files#diff-ca260c219f2b9b36f1eeb68052bd8fdd54e35600742d297a0deac0d3e71a922d) for native EVM payments by replacing the hardcoded `'eth'` prefix with `method.type`, so non-ETH EVM chains produce correct IDs.
> - Adds a 2% underpayment tolerance in both [`eth-settler.ts`](https://github.com/wopr-network/platform-core/pull/78/files#diff-04337e663c9fee99a1c44315f1b85baee26bdb8555d75b9084777ed44ffa2e2d) and [`btc-settler.ts`](https://github.com/wopr-network/platform-core/pull/78/files#diff-b6d7d98a0eb67241c2dd012ad47a4f35122d4ad375652ad952626227ead305cc): payments ≥98% of the expected USD amount are credited in full instead of being zeroed out.
> - Behavioral Change: previously any underpayment resulted in zero credit; now payments within 2% of the charge amount are treated as fully paid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca989b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bitcoin and Ethereum payment settlement validation now includes a 2% underpayment tolerance threshold to account for minor price fluctuations and market drift that may occur during transaction processing.

* **Changes**
  * Reference identifier format for native EVM cryptocurrency payment transactions has been updated to reflect payment method type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->