### PR TITLE
fix: BtcWatcher importdescriptors for modern bitcoind

### DIFF
--- a/src/billing/crypto/btc/watcher.ts
+++ b/src/billing/crypto/btc/watcher.ts
@@ -48,9 +48,27 @@ export class BtcWatcher {
     for (const a of addresses) this.addresses.add(a);
   }
 
-  /** Import an address into bitcoind's wallet (watch-only, no rescan). */
+  /**
+   * Import an address into bitcoind's wallet (watch-only).
+   * Uses `importdescriptors` (modern bitcoind v24+) with fallback to legacy `importaddress`.
+   */
   async importAddress(address: string): Promise<void> {
-    await this.rpc("importaddress", [address, "", false]);
+    try {
+      // Modern bitcoind: get descriptor checksum, then import
+      const info = (await this.rpc("getdescriptorinfo", [`addr(${address})`])) as {
+        descriptor: string;
+      };
+      const result = (await this.rpc("importdescriptors", [[{ desc: info.descriptor, timestamp: 0 }]])) as Array<{
+        success: boolean;
+        error?: { message: string };
+      }>;
+      if (result[0] && !result[0].success) {
+        throw new Error(result[0].error?.message ?? "importdescriptors failed");
+      }
+    } catch {
+      // Fallback: legacy importaddress (bitcoind <v24)
+      await this.rpc("importaddress", [address, "", false]);
+    }
     this.addresses.add(address);
   }
 


### PR DESCRIPTION
## Summary
- bitcoind v30 removed `importaddress` RPC entirely and no longer supports legacy wallets
- BtcWatcher now uses `importdescriptors` with `getdescriptorinfo` checksum
- Falls back to legacy `importaddress` for older bitcoind versions

## Test plan
- [ ] BTC E2E on regtest with modern bitcoind (v30+)
- [ ] Backwards compatible with older bitcoind

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update BTC watcher address import to support modern bitcoind while remaining backwards compatible.

Bug Fixes:
- Restore compatibility of BTC address importing with modern bitcoind versions that removed the importaddress RPC.

Enhancements:
- Use importdescriptors with getdescriptorinfo checksums for watch-only BTC address imports, with automatic fallback to legacy importaddress on older bitcoind nodes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `BtcWatcher.importAddress` to use descriptor-based import for modern bitcoind
> Updates `importAddress` in [watcher.ts](https://github.com/wopr-network/platform-core/pull/80/files#diff-de95ea41130501bbe11c7c6756407f0198dd44cf92fd49d5219b45a07918c11c) to first attempt a modern descriptor import via `getdescriptorinfo` + `importdescriptors`, falling back to the legacy `importaddress` RPC on failure.
>
> - The descriptor path uses `timestamp: 0`, which triggers a full rescan from genesis on modern nodes.
> - Risk: using `timestamp: 0` on a node with a large chain history may cause a significantly longer rescan than the previous `importaddress` call without rescan.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e2cce57. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->