### PR TITLE
feat: createAndStart, network, ephemeral in FleetManager

### DIFF
--- a/src/fleet/fleet-manager.ts
+++ b/src/fleet/fleet-manager.ts
@@ -160,6 +160,19 @@ export class FleetManager {
   }
 
   /**
+   * Create and immediately start a bot container in one call.
+   * Combines create() + start() for ephemeral container workflows.
+   */
+  async createAndStart(
+    params: Omit<BotProfile, "id"> & { id?: string },
+    resourceLimits?: ContainerResourceLimits,
+  ): Promise<BotProfile> {
+    const profile = await this.create(params, resourceLimits);
+    await this.start(profile.id);
+    return profile;
+  }
+
+  /**
    * Start a stopped bot container.
    * Valid from: stopped, created, exited, dead, error states.
    * Throws InvalidStateTransitionError if the container is already running.
@@ -608,23 +621,29 @@ export class FleetManager {
       binds.push(`${sharedVolConfig.volumeName}:${sharedVolConfig.mountPath}:ro`);
     }
 
+    const isEphemeral = profile.ephemeral === true;
+
     const hostConfig: Docker.ContainerCreateOptions["HostConfig"] = {
       RestartPolicy: {
         Name: restartPolicyMap[profile.restartPolicy] || "",
       },
       Binds: binds.length > 0 ? binds : undefined,
-      SecurityOpt: ["no-new-privileges"],
-      CapDrop: ["ALL"],
-      CapAdd: ["NET_BIND_SERVICE"],
-      ReadonlyRootfs: true,
-      Tmpfs: {
-        "/tmp": "rw,noexec,nosuid,size=64m",
-        "/var/tmp": "rw,noexec,nosuid,size=64m",
-      },
+      SecurityOpt: isEphemeral ? undefined : ["no-new-privileges"],
+      CapDrop: isEphemeral ? undefined : ["ALL"],
+      CapAdd: isEphemeral ? undefined : ["NET_BIND_SERVICE"],
+      ReadonlyRootfs: isEphemeral ? false : true,
+      Tmpfs: isEphemeral
+        ? undefined
+        : {
+            "/tmp": "rw,noexec,nosuid,size=64m",
+            "/var/tmp": "rw,noexec,nosuid,size=64m",
+          },
     };
 
-    // Set tenant network isolation if NetworkPolicy is configured
-    if (this.networkPolicy) {
+    // Set network: explicit profile.network takes precedence, then NetworkPolicy
+    if (profile.network) {
+      hostConfig.NetworkMode = profile.network;
+    } else if (this.networkPolicy) {
       const networkMode = await this.networkPolicy.prepareForContainer(profile.tenantId);
       hostConfig.NetworkMode = networkMode;
     }

--- a/src/fleet/types.ts
+++ b/src/fleet/types.ts
@@ -74,6 +74,10 @@ export const botProfileSchema = z.object({
   discovery: discoveryConfigSchema.optional(),
   /** Node this bot was placed on at creation time (optional, for future multi-node routing). */
   nodeId: z.string().uuid().optional(),
+  /** Docker network to attach the container to (bypasses NetworkPolicy). */
+  network: z.string().min(1).optional(),
+  /** When true, disables ReadonlyRootfs and CapDrop for containers that need write access (e.g., ephemeral workers). */
+  ephemeral: z.boolean().optional(),
 });
 
 export type BotProfile = z.infer<typeof botProfileSchema>;
@@ -96,6 +100,10 @@ export const createBotSchema = z.object({
   discovery: discoveryConfigSchema.optional(),
   /** Node this bot was placed on at creation time (optional, for future multi-node routing). */
   nodeId: z.string().uuid().optional(),
+  /** Docker network to attach the container to. */
+  network: z.string().min(1).optional(),
+  /** When true, disables ReadonlyRootfs and CapDrop for ephemeral workers. */
+  ephemeral: z.boolean().optional(),
 });
 
 /** Schema for updating a bot via the API */


### PR DESCRIPTION
## Summary
- `createAndStart()`: creates + starts container in one call (ephemeral workflows)
- `BotProfile.network`: optional Docker network string (bypasses NetworkPolicy)
- `BotProfile.ephemeral`: disables ReadonlyRootfs, CapDrop, SecurityOpt for workers that need write access
- Also added to `createBotSchema` for API callers

Needed by holyship's reactive worker pool to provision ephemeral holyshipper containers on the right Docker network with writable filesystems.

## Test plan
- [x] `pnpm check` passes
- [ ] CI green
- [ ] Downstream: holyship uses createAndStart + network + ephemeral

## Summary by Sourcery

Add support for ephemeral bot containers that can be created and started in a single call, with configurable Docker networking and relaxed security settings when required.

New Features:
- Introduce FleetManager.createAndStart to create and immediately start a bot container in one operation.
- Extend bot profiles and bot creation API to accept an optional Docker network name for containers.
- Add an optional ephemeral flag on bot profiles and creation API to allow writable root filesystems for workers that need it.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `createAndStart`, `network`, and `ephemeral` support to `FleetManager`
> - Adds `FleetManager.createAndStart` in [fleet-manager.ts](https://github.com/wopr-network/platform-core/pull/84/files#diff-6de9b2b6a519952b510e4b2fcffd3d42411043f05f5a041df03d1f932eee2d7b) as a convenience method that composes `create` and `start` into a single call.
> - Adds `ephemeral` flag support to `FleetManager.create`: ephemeral containers skip security hardening (no `SecurityOpt`, `CapDrop`, `CapAdd`, or `Tmpfs`) and run with a writable root filesystem.
> - Adds `network` field support so an explicit Docker network on the profile takes precedence over the `NetworkPolicy`-derived network.
> - Extends `botProfileSchema` and `createBotSchema` in [types.ts](https://github.com/wopr-network/platform-core/pull/84/files#diff-b6698d117a0689340fd106dc5ffa641cae46597f1d2f9096a48ad71f9d42291d) with optional `network` (non-empty string) and `ephemeral` (boolean) fields.
> - Behavioral Change: containers with `ephemeral=true` lose all previously enforced hardening defaults (read-only rootfs, capability drops, tmpfs mounts).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfcb421.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for ephemeral containers with adjusted security settings for temporary workloads.
  * Added ability to specify which Docker network containers attach to.
  * Added streamlined operation to create and start containers in a single step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->