### PR TITLE
fix: debit credits in SSE streaming path

### DIFF
--- a/src/gateway/streaming.ts
+++ b/src/gateway/streaming.ts
@@ -9,6 +9,7 @@
 import { Credit } from "@wopr-network/platform-core/credits";
 import { logger } from "../config/logger.js";
 import { withMargin } from "../monetization/adapters/types.js";
+import { debitCredits } from "./credit-gate.js";
 import type { ProxyDeps } from "./proxy.js";
 import type { SellRateLookupFn } from "./rate-lookup.js";
 import { DEFAULT_TOKEN_RATES, resolveTokenRates } from "./rate-lookup.js";
@@ -119,6 +120,9 @@ export function proxySSEStream(
         provider,
         timestamp: Date.now(),
       });
+
+      // Debit credits (fire-and-forget, same as non-streaming path)
+      debitCredits(deps, tenant.id, accumulatedCost, deps.defaultMargin, capability, provider);
 
       logger.info("Gateway proxy: SSE stream completed", {
         tenant: tenant.id,


### PR DESCRIPTION
SSE streams were metering but never debiting credits. Added debitCredits call in streaming.ts flush().

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix credit debit in SSE streaming path on stream completion
> The SSE streaming path was not debiting tenant credits after stream completion. Adds a fire-and-forget call to `debitCredits` in `proxySSEStream` using the accumulated stream cost and default margin after metering data is emitted.
>
> Risk: Credit deduction now occurs on every SSE stream completion where it was previously skipped entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8518805.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit management in streaming operations to ensure proper tracking and deduction after stream completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->